### PR TITLE
style(web): HotTrend 상세페이지 

### DIFF
--- a/apps/web/public/icons/crown.svg
+++ b/apps/web/public/icons/crown.svg
@@ -1,0 +1,6 @@
+<svg width="19" height="17" viewBox="0 0 19 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4.13831 15.7129L1.75195 6.93702L6.13991 8.39967L9.06521 4.01172L10.8204 8.39967L15.2083 6.93702L13.1606 15.7129L4.13831 15.7129Z" fill="#F2DE4F" stroke="#F2DE4F" stroke-width="1.17012" stroke-linejoin="round"/>
+<circle cx="9.37227" cy="1.67012" r="1.17012" fill="#F2DE4F"/>
+<circle cx="1.17012" cy="4.00703" r="1.17012" fill="#F2DE4F"/>
+<circle cx="16.9689" cy="4.00703" r="1.17012" fill="#F2DE4F"/>
+</svg>

--- a/apps/web/src/app/hottrend/[category]/[rank]/HotTrendInfo.tsx
+++ b/apps/web/src/app/hottrend/[category]/[rank]/HotTrendInfo.tsx
@@ -19,26 +19,26 @@ export default function HotTrendInfo({ convenience, rank }: HotTrendInfoProps) {
 
   return (
     <div className="bg-white px-5 pb-9 pt-5 font-bold">
-      <div className="py-[10px] text-[22px] ">이번주 Hot Trend</div>
+      <div className="text-xl2 py-10px ">이번주 Hot Trend</div>
       <div className="">
-        <div className="flex justify-between border-2 border-[#1E1C1C] bg-[#1E1C1C] px-[15px] py-[9px] text-white">
-          <span className="flex items-center gap-[7px]">
+        <div className="border-main1 bg-main1 px-15px py-9px flex  justify-between border-2 text-white">
+          <span className="gap-7px flex items-center">
             <CrownIcon />
             {prefixZero(info.rank)}
           </span>
           <span className="">Hot Ranking 🔥</span>
         </div>
-        <div className="flex border-2 border-[#1E1C1C]">
+        <div className="border-main1 flex border-2">
           <div>
-            <div className="break-keep px-[17px] py-[21px]">
+            <div className="px-17px py-21px break-keep">
               {info.hottrendTitle}
             </div>
-            <div className="border-t-2 border-[#1E1C1C] px-[17px] py-[4px] font-medium">
+            <div className="border-main1 px-17px py-4px border-t-2 font-medium">
               <div>{info.title}</div>
               <div>{formatNumberWithComma(info.price)}원</div>
             </div>
           </div>
-          <div className="min-w-[152px] border-l-2 border-[#1E1C1C] p-2">
+          <div className="border-main1 min-w-[152px] border-l-2 p-2">
             <div className="relative flex h-full w-full ">
               <Image
                 className="object-contain"
@@ -49,15 +49,15 @@ export default function HotTrendInfo({ convenience, rank }: HotTrendInfoProps) {
             </div>
           </div>
         </div>
-        <div className="break-keep border-x-2 border-[#1E1C1C] px-[40px] py-[9px] text-center text-[15px] font-medium">
+        <div className="border-main1 py-9px px-40px text-15px break-keep border-x-2 text-center font-medium">
           {info.hottrendContent}
         </div>
-        <div className=" border-2 border-[#1E1C1C]">
+        <div className=" border-main1 border-2">
           <Link
-            className="flex w-full items-center justify-center gap-1 bg-[#D3EB6E] p-[9px]"
+            className="p-9px flex w-full items-center justify-center gap-1 bg-[#D3EB6E]"
             href={''}
           >
-            <span className="text-[15px] font-bold">더 알아보기</span>
+            <span className="text-15px font-bold">더 알아보기</span>
             <ChevronRightIcon />
           </Link>
         </div>

--- a/apps/web/src/app/hottrend/[category]/[rank]/HotTrendInfo.tsx
+++ b/apps/web/src/app/hottrend/[category]/[rank]/HotTrendInfo.tsx
@@ -1,0 +1,67 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+import { Convenience } from '@/app/type';
+import ChevronRightIcon from '@/components/icons/ChevronRightIcon';
+import CrownIcon from '@/components/icons/CrownIcon';
+import { hotTrendInfoData } from '@/dummy/hotTrend';
+import { formatNumberWithComma, prefixZero } from '@/utils/numberFormatter';
+
+interface HotTrendInfoProps {
+  convenience: Convenience;
+  rank: number;
+}
+
+export default function HotTrendInfo({ convenience, rank }: HotTrendInfoProps) {
+  const info = hotTrendInfoData.find(
+    (data) => data.rank === Number(rank) && data.convenience === convenience,
+  );
+
+  return (
+    <div className="bg-white px-5 pb-9 pt-5 font-bold">
+      <div className="py-[10px] text-[22px] ">이번주 Hot Trend</div>
+      <div className="">
+        <div className="flex justify-between border-2 border-[#1E1C1C] bg-[#1E1C1C] px-[15px] py-[9px] text-white">
+          <span className="flex items-center gap-[7px]">
+            <CrownIcon />
+            {prefixZero(info.rank)}
+          </span>
+          <span className="">Hot Ranking 🔥</span>
+        </div>
+        <div className="flex border-2 border-[#1E1C1C]">
+          <div>
+            <div className="break-keep px-[17px] py-[21px]">
+              {info.hottrendTitle}
+            </div>
+            <div className="border-t-2 border-[#1E1C1C] px-[17px] py-[4px] font-medium">
+              <div>{info.title}</div>
+              <div>{formatNumberWithComma(info.price)}원</div>
+            </div>
+          </div>
+          <div className="min-w-[152px] border-l-2 border-[#1E1C1C] p-2">
+            <div className="relative flex h-full w-full ">
+              <Image
+                className="object-contain"
+                src={info.imageUrl}
+                alt={info.title}
+                fill
+              />
+            </div>
+          </div>
+        </div>
+        <div className="break-keep border-x-2 border-[#1E1C1C] px-[40px] py-[9px] text-center text-[15px] font-medium">
+          {info.hottrendContent}
+        </div>
+        <div className=" border-2 border-[#1E1C1C]">
+          <Link
+            className="flex w-full items-center justify-center gap-1 bg-[#D3EB6E] p-[9px]"
+            href={''}
+          >
+            <span className="text-[15px] font-bold">더 알아보기</span>
+            <ChevronRightIcon />
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/hottrend/[category]/[rank]/HotTrendRankList.tsx
+++ b/apps/web/src/app/hottrend/[category]/[rank]/HotTrendRankList.tsx
@@ -12,7 +12,7 @@ export default function HotTrendRankList({ category }: HotTrendRankListProps) {
   );
 
   return (
-    <div className="hdr s mt-4 bg-white px-5 py-9">
+    <div className="mt-4 bg-white px-5 py-9">
       <div className="text-xl2 font-bold">
         <div className="flex items-center">
           이번주 [

--- a/apps/web/src/app/hottrend/[category]/[rank]/HotTrendRankList.tsx
+++ b/apps/web/src/app/hottrend/[category]/[rank]/HotTrendRankList.tsx
@@ -1,0 +1,34 @@
+import { Convenience } from '@/app/type';
+import HotTrendCard from '@/components/HotTrendItem';
+import { mainHotTrendData } from '@/dummy/hotTrend';
+
+interface HotTrendRankListProps {
+  category: Convenience;
+}
+
+export default function HotTrendRankList({ category }: HotTrendRankListProps) {
+  const hotTrendData = mainHotTrendData.filter(
+    (one) => one.convenience === category,
+  );
+
+  return (
+    <div className="hdr s mt-4 bg-white px-5 py-9">
+      <div className="title text-[22px] font-bold">
+        <div className="flex items-center">
+          이번주 [
+          <div className="relative mx-2">
+            <span className="relative z-10">{category}</span>
+            <hr className="absolute bottom-[5px] left-0 h-3 w-full bg-[#ffd700]" />
+          </div>
+          ]
+        </div>
+        <div>Hot Trend🔥 랭킹</div>
+      </div>
+      <div className="mt-8 flex flex-col gap-5">
+        {hotTrendData.map((props) => (
+          <HotTrendCard key={props.id} {...props} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/hottrend/[category]/[rank]/HotTrendRankList.tsx
+++ b/apps/web/src/app/hottrend/[category]/[rank]/HotTrendRankList.tsx
@@ -13,12 +13,12 @@ export default function HotTrendRankList({ category }: HotTrendRankListProps) {
 
   return (
     <div className="hdr s mt-4 bg-white px-5 py-9">
-      <div className="title text-[22px] font-bold">
+      <div className="text-xl2 font-bold">
         <div className="flex items-center">
           이번주 [
           <div className="relative mx-2">
             <span className="relative z-10">{category}</span>
-            <hr className="absolute bottom-[5px] left-0 h-3 w-full bg-[#ffd700]" />
+            <hr className="bg-gold bottom-5px absolute left-0 h-3 w-full" />
           </div>
           ]
         </div>

--- a/apps/web/src/app/hottrend/[category]/[rank]/page.tsx
+++ b/apps/web/src/app/hottrend/[category]/[rank]/page.tsx
@@ -1,0 +1,19 @@
+import { Convenience } from '@/app/type';
+
+import HotTrendInfo from './HotTrendInfo';
+import HotTrendRankList from './HotTrendRankList';
+
+interface CategoryPageProps {
+  params: { category: Convenience; rank: number };
+}
+
+export default function HotTrendCategoryRankInfoPage({
+  params: { category, rank },
+}: CategoryPageProps) {
+  return (
+    <>
+      <HotTrendInfo convenience={category} rank={rank} />
+      <HotTrendRankList category={category} />
+    </>
+  );
+}

--- a/apps/web/src/app/hottrend/[category]/layout.tsx
+++ b/apps/web/src/app/hottrend/[category]/layout.tsx
@@ -1,0 +1,31 @@
+import { ReactNode } from 'react';
+
+import { Convenience } from '@/app/type';
+import TabCategory from '@/components/TabCategory';
+
+interface HotTrendCategoryLayoutProps {
+  params: { category: Convenience };
+  children: ReactNode;
+}
+
+const conveniences: Convenience[] = ['CU', 'GS25', '7Eleven', 'Emart24'];
+const categoryInfoList = conveniences.map((convenience) => ({
+  label: convenience,
+  href: `/hottrend/${convenience}/1`,
+}));
+
+export default function HotTrendCategoryLayout({
+  children,
+  params: { category },
+}: HotTrendCategoryLayoutProps) {
+  return (
+    <div>
+      <TabCategory
+        categoryData={categoryInfoList}
+        currentCategory={category}
+        isRouterReplace
+      />
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/app/hottrend/[category]/layout.tsx
+++ b/apps/web/src/app/hottrend/[category]/layout.tsx
@@ -20,11 +20,13 @@ export default function HotTrendCategoryLayout({
 }: HotTrendCategoryLayoutProps) {
   return (
     <div>
-      <TabCategory
-        categoryData={categoryInfoList}
-        currentCategory={category}
-        isRouterReplace
-      />
+      <div className="sticky top-[58px] z-40">
+        <TabCategory
+          categoryData={categoryInfoList}
+          currentCategory={category}
+          isRouterReplace
+        />
+      </div>
       {children}
     </div>
   );

--- a/apps/web/src/app/hottrend/layout.tsx
+++ b/apps/web/src/app/hottrend/layout.tsx
@@ -8,19 +8,17 @@ interface HotTrendLayoutProps {
 
 export default function HotTrendLayout({ children }: HotTrendLayoutProps) {
   return (
-    <div className="min-w-[360px] max-w-[390px] flex-1">
-      <BasicLayout
-        hasBackButton
-        headerCenter={'이번주 Hot Trend'}
-        headerRight={
-          <div className="flex items-center">
-            <HomeIconButton />
-            <SearchIconButton />
-          </div>
-        }
-      >
-        {children}
-      </BasicLayout>
-    </div>
+    <BasicLayout
+      hasBackButton
+      headerCenter={'이번주 Hot Trend'}
+      headerRight={
+        <div className="flex items-center">
+          <HomeIconButton />
+          <SearchIconButton />
+        </div>
+      }
+    >
+      {children}
+    </BasicLayout>
   );
 }

--- a/apps/web/src/app/hottrend/layout.tsx
+++ b/apps/web/src/app/hottrend/layout.tsx
@@ -1,0 +1,26 @@
+import BasicLayout from '@/components/BasicLayout';
+import HomeIconButton from '@/components/HomeIconButton';
+import SearchIconButton from '@/components/SearchIconButton';
+
+interface HotTrendLayoutProps {
+  children: React.ReactNode;
+}
+
+export default function HotTrendLayout({ children }: HotTrendLayoutProps) {
+  return (
+    <div className="min-w-[360px] max-w-[390px] flex-1">
+      <BasicLayout
+        hasBackButton
+        headerCenter={'이번주 Hot Trend'}
+        headerRight={
+          <div className="flex items-center">
+            <HomeIconButton />
+            <SearchIconButton />
+          </div>
+        }
+      >
+        {children}
+      </BasicLayout>
+    </div>
+  );
+}

--- a/apps/web/src/app/main/[category]/EventItems.tsx
+++ b/apps/web/src/app/main/[category]/EventItems.tsx
@@ -15,7 +15,7 @@ export default function EventItems({ convenience }: EventItemsProps) {
     router.push(`/event/${convenience}`);
   };
   return (
-    <div className="rounded-t-[30px] bg-white px-[20px] pb-[10px] pt-[27px]">
+    <div className="pb-10px rounded-t-[30px] bg-white px-[20px] pt-[27px]">
       <div className="mb-[50px] flex flex-wrap items-start justify-start gap-x-[18px] gap-y-[50px]">
         {Array.from({ length: 8 }).map((_, i) => (
           <EventItemCard

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -4,12 +4,12 @@ import Error from 'next/error';
 import { redirect, usePathname } from 'next/navigation';
 
 export default function NotFound() {
-  const path = usePathname();
+  const segmentList = usePathname().split('/');
 
-  switch (path) {
-    case '/hottrend':
-      return redirect('/hottrend/CU');
-    case '/event':
+  switch (true) {
+    case segmentList.includes('hottrend'):
+      return redirect('/hottrend/CU/1');
+    case segmentList.includes('event'):
       return redirect('/event/ALL');
     default:
       return <Error statusCode={404} />;

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import Error from 'next/error';
+import { redirect, usePathname } from 'next/navigation';
+
+export default function NotFound() {
+  const path = usePathname();
+
+  switch (path) {
+    case '/hottrend':
+      return redirect('/hottrend/CU');
+    case '/event':
+      return redirect('/event/ALL');
+    default:
+      return <Error statusCode={404} />;
+  }
+}

--- a/apps/web/src/assets/chevronRight.svg
+++ b/apps/web/src/assets/chevronRight.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="19" viewBox="0 0 18 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7 14L12.5 9.5L7 5" stroke="#1E1C1C" stroke-width="1.52349" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/apps/web/src/components/HotTrendItem/index.tsx
+++ b/apps/web/src/components/HotTrendItem/index.tsx
@@ -25,7 +25,7 @@ export default function HotTrendCard({
   return (
     <div className="min-h-[165px]  w-full">
       <Link href={`/hottrend/${convenience}/${rank}`}>
-        <div className="relative flex  h-[165px] rounded-[9px] border-2 border-b-[3px] border-r-[7px] border-[#1E1C1C] p-[10px]">
+        <div className="p-10px relative  flex h-[165px] rounded-[9px] border-2 border-b-[3px] border-r-[7px] border-[#1E1C1C]">
           <div className="relative my-2 ml-[27px] flex-1">
             <Image
               className="object-contain"
@@ -36,7 +36,7 @@ export default function HotTrendCard({
           </div>
           <div className="mt-[46px] w-[168px]">
             <div>
-              <span className="rounded-sm border-[1px] border-[#1E1C1C] px-[7px] py-[2px] font-bold leading-none">
+              <span className="px-7px py-2px rounded-sm border-[1px]  border-[#1E1C1C]  font-bold leading-none">
                 {convenience}
               </span>
             </div>
@@ -44,7 +44,7 @@ export default function HotTrendCard({
               {title}
             </div>
             <div className="mt-[2px] leading-none">
-              <span className="text-[22px] font-bold ">
+              <span className="text-xl2 font-bold ">
                 {formatNumberWithComma(price)}
               </span>
               <span>원</span>

--- a/apps/web/src/components/HotTrendItem/index.tsx
+++ b/apps/web/src/components/HotTrendItem/index.tsx
@@ -1,8 +1,8 @@
 import Image from 'next/image';
+import Link from 'next/link';
 
 import { Convenience } from '@/app/type';
 import RankBox from '@/components/RankBox';
-import { pyeonImage } from '@/dummy/image';
 import { formatNumberWithComma } from '@/utils/numberFormatter';
 
 interface HotTrendCardProps {
@@ -17,42 +17,44 @@ interface HotTrendCardProps {
 export default function HotTrendCard({
   id,
   rank,
-  imageUrl = pyeonImage,
+  imageUrl,
   price,
   title,
   convenience,
 }: HotTrendCardProps) {
   return (
     <div className="min-h-[165px]  w-full">
-      <div className="relative flex  h-[165px] rounded-[9px] border-2 border-b-[3px] border-r-[7px] border-[#1E1C1C] p-[10px]">
-        <div className="relative my-2 ml-[27px] flex-1">
-          <Image
-            className="object-contain"
-            src={imageUrl}
-            fill
-            alt={`hottrend-${title}`}
-          />
-        </div>
-        <div className="mt-[46px] w-[168px]">
-          <div>
-            <span className="rounded-sm border-[1px] border-[#1E1C1C] px-[7px] py-[2px] font-bold leading-none">
-              {convenience}
-            </span>
+      <Link href={`/hottrend/${convenience}/${rank}`}>
+        <div className="relative flex  h-[165px] rounded-[9px] border-2 border-b-[3px] border-r-[7px] border-[#1E1C1C] p-[10px]">
+          <div className="relative my-2 ml-[27px] flex-1">
+            <Image
+              className="object-contain"
+              src={imageUrl}
+              fill
+              alt={`hottrend-${title}`}
+            />
           </div>
-          <div className="mt-[11px] truncate text-base font-medium	leading-none">
-            {title}
+          <div className="mt-[46px] w-[168px]">
+            <div>
+              <span className="rounded-sm border-[1px] border-[#1E1C1C] px-[7px] py-[2px] font-bold leading-none">
+                {convenience}
+              </span>
+            </div>
+            <div className="mt-[11px] truncate text-base font-medium	leading-none">
+              {title}
+            </div>
+            <div className="mt-[2px] leading-none">
+              <span className="text-[22px] font-bold ">
+                {formatNumberWithComma(price)}
+              </span>
+              <span>원</span>
+            </div>
           </div>
-          <div className="mt-[2px] leading-none">
-            <span className="text-[22px] font-bold ">
-              {formatNumberWithComma(price)}
-            </span>
-            <span>원</span>
+          <div className="absolute">
+            <RankBox rank={rank} />
           </div>
         </div>
-        <div className="absolute">
-          <RankBox rank={rank} />
-        </div>
-      </div>
+      </Link>
     </div>
   );
 }

--- a/apps/web/src/components/HotTrendItem/index.tsx
+++ b/apps/web/src/components/HotTrendItem/index.tsx
@@ -1,8 +1,9 @@
 import Image from 'next/image';
 
 import { Convenience } from '@/app/type';
+import RankBox from '@/components/RankBox';
 import { pyeonImage } from '@/dummy/image';
-import { formatNumberWithComma, prefixZero } from '@/utils/numberFormatter';
+import { formatNumberWithComma } from '@/utils/numberFormatter';
 
 interface HotTrendCardProps {
   id: string | number;
@@ -48,8 +49,8 @@ export default function HotTrendCard({
             <span>원</span>
           </div>
         </div>
-        <div className="absolute bg-[#1E1C1C] p-2 text-[19px] font-extrabold leading-5 text-white">
-          {prefixZero(rank)}
+        <div className="absolute">
+          <RankBox rank={rank} />
         </div>
       </div>
     </div>

--- a/apps/web/src/components/RankBox/index.tsx
+++ b/apps/web/src/components/RankBox/index.tsx
@@ -1,0 +1,13 @@
+import { prefixZero } from '@/utils/numberFormatter';
+
+interface RankBoxProps {
+  rank: number;
+}
+
+export default function RankBox({ rank }: RankBoxProps) {
+  return (
+    <div className="bg-[#1E1C1C] p-2 text-[19px] font-extrabold leading-5 text-white">
+      {prefixZero(rank)}
+    </div>
+  );
+}

--- a/apps/web/src/components/TabBar/OneBar.tsx
+++ b/apps/web/src/components/TabBar/OneBar.tsx
@@ -11,7 +11,7 @@ interface OneBarProps {
 export default function OneBar({ isActive, children, onClick }: OneBarProps) {
   return (
     <div
-      className={`flex flex-1 justify-center rounded-full py-[10px]
+      className={`py-10px flex flex-1 justify-center rounded-full
       ${isActive && 'bg-[#1E1C1C] text-white'}   
     `}
       onClick={onClick}

--- a/apps/web/src/components/TabBar/index.tsx
+++ b/apps/web/src/components/TabBar/index.tsx
@@ -9,7 +9,7 @@ interface TabBarProps {
 
 export default function TabBar({ currentIndex, onClick }: TabBarProps) {
   return (
-    <div className="flex rounded-full bg-white p-[5px]">
+    <div className="p-5px flex rounded-full bg-white">
       <OneBar isActive={0 === currentIndex} onClick={() => onClick(0)}>
         이번주 Hot Trend
       </OneBar>

--- a/apps/web/src/components/TabCategory/OneCategory.tsx
+++ b/apps/web/src/components/TabCategory/OneCategory.tsx
@@ -21,7 +21,7 @@ export default function OneCategory({
   return (
     <div
       className={`flex-shrink flex-grow basis-0 text-center
-      ${isActive && 'shadow-[inset_0_-3px_0_0_#73F69D]'}
+      ${isActive && 'font-bold shadow-[inset_0_-3px_0_0_#73F69D]'}
       `}
       onClick={onClick}
     >

--- a/apps/web/src/components/icons/ChevronRightIcon.tsx
+++ b/apps/web/src/components/icons/ChevronRightIcon.tsx
@@ -1,0 +1,5 @@
+import ChevronRight from '@/assets/chevronRight.svg';
+
+export default function ChevronRightIcon() {
+  return <ChevronRight />;
+}

--- a/apps/web/src/components/icons/CrownIcon.tsx
+++ b/apps/web/src/components/icons/CrownIcon.tsx
@@ -1,0 +1,5 @@
+import Crown from 'public/icons/crown.svg';
+
+export default function CrownIcon() {
+  return <Crown />;
+}

--- a/apps/web/src/dummy/hotTrend.ts
+++ b/apps/web/src/dummy/hotTrend.ts
@@ -17,7 +17,7 @@ export const mainHotTrendData: {
     convenience: 'CU',
   },
   {
-    id: 1,
+    id: 2,
     rank: 1,
     imageUrl: '/image/8801007423180.jpg',
     price: 5000,
@@ -25,7 +25,7 @@ export const mainHotTrendData: {
     convenience: 'GS25',
   },
   {
-    id: 1,
+    id: 3,
     rank: 1,
     imageUrl: '/image/MzE2MTE=.jpg',
     price: 5000,
@@ -33,7 +33,7 @@ export const mainHotTrendData: {
     convenience: '7Eleven',
   },
   {
-    id: 1,
+    id: 4,
     rank: 1,
     imageUrl: '/image/671843.jpg',
     price: 5000,
@@ -41,7 +41,7 @@ export const mainHotTrendData: {
     convenience: 'Emart24',
   },
   {
-    id: 1,
+    id: 5,
     rank: 2,
     imageUrl: '/image/GD_2800100153426_001.jpg',
     price: 5000,
@@ -49,7 +49,7 @@ export const mainHotTrendData: {
     convenience: 'CU',
   },
   {
-    id: 1,
+    id: 6,
     rank: 2,
     imageUrl: '/image/GD_8801056150013_007.jpg',
     price: 5000,

--- a/apps/web/src/dummy/hotTrend.ts
+++ b/apps/web/src/dummy/hotTrend.ts
@@ -1,13 +1,15 @@
 import { Convenience } from '@/app/type';
 
-export const mainHotTrendData: {
+type MainHotTrendInfo = {
   id: string | number;
   rank: number;
   imageUrl: string;
   price: number;
   title: string;
   convenience: Convenience;
-}[] = [
+};
+
+export const mainHotTrendData: MainHotTrendInfo[] = [
   {
     id: 1,
     rank: 1,
@@ -51,6 +53,93 @@ export const mainHotTrendData: {
   {
     id: 6,
     rank: 2,
+    imageUrl: '/image/GD_8801056150013_007.jpg',
+    price: 5000,
+    title: '펩시 500ml 캔',
+    convenience: 'GS25',
+  },
+];
+
+type HotTrendInfo = {
+  id: string | number;
+  rank: number;
+  imageUrl: string;
+  price: number;
+  title: string;
+  convenience: Convenience;
+  hottrendTitle: string;
+  hottrendContent: string;
+  moreUrl?: string;
+};
+
+export const hotTrendInfoData: HotTrendInfo[] = [
+  {
+    id: 1,
+    rank: 1,
+    hottrendTitle: '편의점 오픈런의 주인공, 아사히 생맥!',
+    hottrendContent:
+      '캔뚜껑이 완전히 열려서 구름 같은 맥주거품이 쌓이는 재미가 포인트!',
+    moreUrl: '',
+    imageUrl: '/image/8809196615577.jpg',
+    price: 5000,
+    title: '백종원의 연탄불고기',
+    convenience: 'CU',
+  },
+  {
+    id: 2,
+    rank: 1,
+    hottrendTitle: '편의점 오픈런의 주인공, 아사히 생맥!',
+    hottrendContent:
+      '캔뚜껑이 완전히 열려서 구름 같은 맥주거품이 쌓이는 재미가 포인트!',
+    moreUrl: '',
+    imageUrl: '/image/8801007423180.jpg',
+    price: 5000,
+    title: '햇반컵반 강된장 보리비빔밥',
+    convenience: 'GS25',
+  },
+  {
+    id: 3,
+    rank: 1,
+    hottrendTitle: '편의점 오픈런의 주인공, 아사히 생맥!',
+    hottrendContent:
+      '캔뚜껑이 완전히 열려서 구름 같은 맥주거품이 쌓이는 재미가 포인트!',
+    moreUrl: '',
+    imageUrl: '/image/MzE2MTE=.jpg',
+    price: 5000,
+    title: '혜장라면',
+    convenience: '7Eleven',
+  },
+  {
+    id: 4,
+    rank: 1,
+    hottrendTitle: '편의점 오픈런의 주인공, 아사히 생맥!',
+    hottrendContent:
+      '캔뚜껑이 완전히 열려서 구름 같은 맥주거품이 쌓이는 재미가 포인트!',
+    moreUrl: '',
+    imageUrl: '/image/671843.jpg',
+    price: 5000,
+    title: '빙그레 딸기타임',
+    convenience: 'Emart24',
+  },
+  {
+    id: 5,
+    rank: 2,
+    hottrendTitle: '편의점 오픈런의 주인공, 아사히 생맥!',
+    hottrendContent:
+      '캔뚜껑이 완전히 열려서 구름 같은 맥주거품이 쌓이는 재미가 포인트!',
+    moreUrl: '',
+    imageUrl: '/image/GD_2800100153426_001.jpg',
+    price: 5000,
+    title: '캐나다 한끼스테이크',
+    convenience: 'CU',
+  },
+  {
+    id: 6,
+    rank: 2,
+    hottrendTitle: '편의점 오픈런의 주인공, 아사히 생맥!',
+    hottrendContent:
+      '캔뚜껑이 완전히 열려서 구름 같은 맥주거품이 쌓이는 재미가 포인트!',
+    moreUrl: '',
     imageUrl: '/image/GD_8801056150013_007.jpg',
     price: 5000,
     title: '펩시 500ml 캔',

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -8,6 +8,35 @@ module.exports = {
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
+  theme: {
+    extend: {
+      colors: {
+        main1: '#1E1C1C',
+        gold: '#ffd700',
+      },
+      fontSize: {
+        xl2: '22px',
+        '15px': '15px',
+      },
+      width: {
+        '1px': '1px',
+        '3px': '3px',
+        '7px': '7px',
+      },
+      spacing: {
+        '2px': '2px',
+        '4px': '4px',
+        '7px': '7px',
+        '5px': '5px',
+        '9px': '9px',
+        '10px': '10px',
+        '15px': '15px',
+        '17px': '17px',
+        '21px': '21px',
+        '40px': '40px',
+      },
+    },
+  },
   safelist: ['bg-[#73F69D]', 'bg-[#E2F981]', 'bg-[#FFA8A5]', 'bg-[#C29DF6]'],
   plugins: [],
 };


### PR DESCRIPTION
## 한 줄 요약
HotTrend 상세 페이지 UI 작업 

## 자세한 내용 [[시안]](https://www.figma.com/file/86ovly8Q7xMD1S7HqU80eq/%EB%B9%84%EC%82%AC%EC%9D%B4%EB%93%9C-%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8-9%ED%8C%80?type=design&node-id=1607-14347&mode=dev)


### 전체 페이지 

![hottrend1](https://github.com/HAND-PYEON/handpyeon-web/assets/57323359/36d7389c-07a8-4b1a-aa9b-c9efa6eda58a)

### 상단 정보 뷰
![image](https://github.com/HAND-PYEON/handpyeon-web/assets/57323359/3ddf147c-4dee-4cd9-8586-e7d177f1be2c)
- HotTrendInfo : 랭크, 핫트렌드 타이틀, 콘텐츠, 상품 정보, 더 알아보기 

### 하단 리스트 
![image](https://github.com/HAND-PYEON/handpyeon-web/assets/57323359/2fbbdf2d-d673-4f8c-8616-5a7bcdff6173)
- HotTrendRankList : 각 편의점별 핫트렌드 아이템 리스트

### 그외 기타 
- hottrend/layout.tsx : 기본 레이아웃, 최상단 헤더
- hottrend/[category]/layout.tsx : 상단 탭 편의점 카테고리 ( +isRouterReplace )
- not-found : `/hottrend` 경로 중에 not found 일어날 경우 리다이렉트 
- tailwind.config.js : Arbitrary values 로 사용하던 부분을 tailwind.config에 설정해서 이용 