### PR TITLE
feat(web): 서버 api 연동을 위한 템플릿 작업

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -8,6 +8,16 @@ const nextConfig = {
 
     return config;
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'http',
+        hostname: 'tqklhszfkvzk6518638.cdn.ntruss.com',
+        port: '',
+        pathname: '/**',
+      },
+    ],
+  },
 };
 
 module.exports = nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^4.29.19",
-    "@tanstack/react-query-devtools": "^4.29.19",
     "next": "13.4.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",
@@ -21,6 +20,7 @@
   },
   "devDependencies": {
     "@svgr/webpack": "^8.0.1",
+    "@tanstack/react-query-devtools": "^4.29.19",
     "@types/node": "20.1.4",
     "@types/react": "18.2.6",
     "@types/react-dom": "18.2.4",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
     "lint-fix": "eslint --fix \"./**/*.{js,jsx,ts,tsx}\" --ignore-path .gitignore"
   },
   "dependencies": {
+    "@tanstack/react-query": "^4.29.19",
     "next": "13.4.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^4.29.19",
+    "@tanstack/react-query-devtools": "^4.29.19",
     "next": "13.4.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/apps/web/src/apis/promotion.ts
+++ b/apps/web/src/apis/promotion.ts
@@ -1,0 +1,16 @@
+import httpClient from '@/http/client';
+import { Convenience, type PromotionGoods } from './type';
+
+export type PromotionGoodsParams = Convenience | 'ALL';
+
+export const getPromotionGoods = async (params: PromotionGoodsParams) => {
+  const { data } = await httpClient.get<{ data: PromotionGoods[] }>(
+    '/handpyeon/api/promotionGoods',
+    {
+      params: {
+        type: params,
+      },
+    },
+  );
+  return data.data;
+};

--- a/apps/web/src/apis/promotion.ts
+++ b/apps/web/src/apis/promotion.ts
@@ -1,7 +1,7 @@
 import httpClient from '@/http/client';
-import { Convenience, type PromotionGoods } from './type';
+import type { storeName, PromotionGoods } from './type';
 
-export type PromotionGoodsParams = Convenience | 'ALL';
+export type PromotionGoodsParams = storeName | 'ALL';
 
 export const getPromotionGoods = async (params: PromotionGoodsParams) => {
   const { data } = await httpClient.get<{ data: PromotionGoods[] }>(

--- a/apps/web/src/apis/type.ts
+++ b/apps/web/src/apis/type.ts
@@ -1,0 +1,18 @@
+export type Convenience = 'CU' | 'GS25' | '7ELEVEN' | 'EMART24';
+export type PromotionType =
+  | 'ONE_PLUS_ONE'
+  | 'TWO_PLUS_ONE'
+  | 'THREE_PLUS_ONE'
+  | 'SALE'
+  | 'BONUS'
+  | 'PB'
+  | 'GIFT';
+
+export interface PromotionGoods {
+  goodsNo: number;
+  goodsName: string;
+  goodsPrice: number;
+  goodsImageUrl: string;
+  promotionType: PromotionType;
+  storeName: Convenience;
+}

--- a/apps/web/src/apis/type.ts
+++ b/apps/web/src/apis/type.ts
@@ -1,4 +1,4 @@
-export type Convenience = 'CU' | 'GS25' | '7ELEVEN' | 'EMART24';
+export type storeName = 'CU' | 'GS25' | '7ELEVEN' | 'EMART24';
 export type PromotionType =
   | 'ONE_PLUS_ONE'
   | 'TWO_PLUS_ONE'
@@ -14,5 +14,5 @@ export interface PromotionGoods {
   goodsPrice: number;
   goodsImageUrl: string;
   promotionType: PromotionType;
-  storeName: Convenience;
+  storeName: storeName;
 }

--- a/apps/web/src/app/appProviders.tsx
+++ b/apps/web/src/app/appProviders.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useState } from 'react';
+
+export default function AppProviders({ children }) {
+  const [queryClient] = useState(() => new QueryClient());
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/apps/web/src/app/appProviders.tsx
+++ b/apps/web/src/app/appProviders.tsx
@@ -1,12 +1,16 @@
 'use client';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { useState } from 'react';
 
 export default function AppProviders({ children }) {
   const [queryClient] = useState(() => new QueryClient());
 
   return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={queryClient}>
+      <ReactQueryDevtools initialIsOpen={false} />
+      {children}
+    </QueryClientProvider>
   );
 }

--- a/apps/web/src/app/appProviders.tsx
+++ b/apps/web/src/app/appProviders.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import GlobalErrorBoundary from '@/components/GlobalErrorBoundary';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { useState } from 'react';
@@ -8,9 +9,11 @@ export default function AppProviders({ children }) {
   const [queryClient] = useState(() => new QueryClient());
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <ReactQueryDevtools initialIsOpen={false} />
-      {children}
-    </QueryClientProvider>
+    <GlobalErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <ReactQueryDevtools initialIsOpen={false} />
+        {children}
+      </QueryClientProvider>
+    </GlobalErrorBoundary>
   );
 }

--- a/apps/web/src/app/event/[category]/components/EventItemSection.tsx
+++ b/apps/web/src/app/event/[category]/components/EventItemSection.tsx
@@ -33,7 +33,7 @@ const EventItemSection = () => {
               imageUrl: pyeonImage,
               price: 20000,
               title: 'asdfasdf',
-              convenience: '7Eleven',
+              convenience: '7ELEVEN',
             }}
           />
         ))}

--- a/apps/web/src/app/event/[category]/detail/[id]/components/EventItemDetailCard.tsx
+++ b/apps/web/src/app/event/[category]/detail/[id]/components/EventItemDetailCard.tsx
@@ -1,11 +1,12 @@
-import { Convenience, EventType } from '@/app/type';
+import { Convenience } from '@/app/type';
 import { formatNumberWithComma } from '@/utils/numberFormatter';
 import Image from 'next/image';
 import { EVENT_TYPE_MAP } from '@/constants/conveniences';
+import { type PromotionType } from '@/apis/type';
 
 interface EventItemDetailCardProps {
   category: Convenience;
-  eventType: EventType;
+  eventType: PromotionType;
   imageUrl: string;
   productName: string;
   price: number;

--- a/apps/web/src/app/event/[category]/detail/[id]/components/EventItemDetailSection.tsx
+++ b/apps/web/src/app/event/[category]/detail/[id]/components/EventItemDetailSection.tsx
@@ -12,7 +12,7 @@ const EventItemDetailSection = () => {
       </div>
       <div className="pb-[37px]">
         <EventItemDetailCard
-          category="Emart24"
+          category="EMART24"
           eventType="BONUS"
           imageUrl={pyeonImage}
           productName="스프라이트P500ml"

--- a/apps/web/src/app/event/[category]/detail/[id]/components/EventItemTotalSection.tsx
+++ b/apps/web/src/app/event/[category]/detail/[id]/components/EventItemTotalSection.tsx
@@ -23,7 +23,7 @@ const EventItemTotalSection = () => {
               imageUrl: pyeonImage,
               price: 20000,
               title: 'asdfasdf',
-              convenience: '7Eleven',
+              convenience: '7ELEVEN',
             }}
           />
         ))}

--- a/apps/web/src/app/event/[category]/detail/[id]/page.tsx
+++ b/apps/web/src/app/event/[category]/detail/[id]/page.tsx
@@ -10,9 +10,9 @@ import EventItemDetailSection from './components/EventItemDetailSection';
 import EventItemTotalSection from './components/EventItemTotalSection';
 
 const categoryInfoList = CONVENIENCE.map((convenience) => ({
-  category: convenience,
+  category: convenience.toUpperCase(),
   label: convenience,
-  href: `/event/${convenience}`,
+  href: `/event/${convenience.toUpperCase()}`,
 }));
 
 interface EventItemDetailPageProps {

--- a/apps/web/src/app/event/[category]/page.tsx
+++ b/apps/web/src/app/event/[category]/page.tsx
@@ -9,9 +9,9 @@ import SearchIconButton from '@/components/SearchIconButton';
 import { CONVENIENCE } from '@/constants/conveniences';
 
 const categoryInfoList = CONVENIENCE.map((convenience) => ({
-  category: convenience,
+  category: convenience.toUpperCase(),
   label: convenience,
-  href: `/event/${convenience}`,
+  href: `/event/${convenience.toUpperCase()}`,
 }));
 
 interface EventCategoryPageProps {

--- a/apps/web/src/app/getQueryClient.tsx
+++ b/apps/web/src/app/getQueryClient.tsx
@@ -1,0 +1,5 @@
+import { cache } from 'react';
+import { QueryClient } from '@tanstack/react-query';
+
+const getQueryClient = cache(() => new QueryClient());
+export default getQueryClient;

--- a/apps/web/src/app/hottrend/[category]/layout.tsx
+++ b/apps/web/src/app/hottrend/[category]/layout.tsx
@@ -2,17 +2,19 @@ import { ReactNode } from 'react';
 
 import { Convenience } from '@/app/type';
 import TabCategory from '@/components/TabCategory';
+import { CONVENIENCE } from '@/constants/conveniences';
 
 interface HotTrendCategoryLayoutProps {
   params: { category: Convenience };
   children: ReactNode;
 }
 
-const conveniences: Convenience[] = ['CU', '7Eleven', 'GS25', 'Emart24'];
-const categoryInfoList = conveniences.map((convenience) => ({
-  category: convenience,
+const convenienceList = CONVENIENCE.filter((item) => item !== 'ALL');
+
+const categoryInfoList = convenienceList.map((convenience) => ({
+  category: convenience.toUpperCase(),
   label: convenience,
-  href: `/hottrend/${convenience}/1`,
+  href: `/hottrend/${convenience.toUpperCase()}/1`,
 }));
 
 export default function HotTrendCategoryLayout({

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import 'ui/styles.css';
 import './globals.css';
 
 import localFont from 'next/font/local';
+import AppProviders from './appProviders';
 
 const pretendard = localFont({
   src: '../../public/font/PretendardVariable.woff2',
@@ -22,7 +23,7 @@ export default function RootLayout({
       <body className={`${pretendard.className} h-full`}>
         <main className="flex min-h-full w-full justify-center">
           <div className="flex w-full min-w-[360px] max-w-[390px] flex-col">
-            {children}
+            <AppProviders>{children}</AppProviders>
           </div>
         </main>
       </body>

--- a/apps/web/src/app/main/CategoryChildren.tsx
+++ b/apps/web/src/app/main/CategoryChildren.tsx
@@ -30,7 +30,9 @@ export default function CategoryChildren({
       <div className="top-[53px] z-auto px-[20px] py-[19px]">
         <TabBar currentIndex={currentIndex} onClick={handleTabBarClick} />
       </div>
-      <div>{children[currentIndex]}</div>
+      <div className="pb-10px rounded-t-[30px] bg-white px-[20px] pt-[27px]">
+        {children[currentIndex]}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/main/[category]/EventItems.tsx
+++ b/apps/web/src/app/main/[category]/EventItems.tsx
@@ -3,6 +3,7 @@ import { Convenience } from '@/app/type';
 import EventItemCard from '@/components/EventItemCard';
 import ChevronIcon from '@/components/icons/ChevronIcon';
 import { pyeonImage } from '@/dummy/image';
+import { useGetPromotionGoods } from '@/hooks/query/usePromotion';
 import { useRouter } from 'next/navigation';
 
 interface EventItemsProps {
@@ -11,21 +12,22 @@ interface EventItemsProps {
 
 export default function EventItems({ convenience }: EventItemsProps) {
   const router = useRouter();
+  const { data } = useGetPromotionGoods(convenience);
   const goEventPage = () => {
     router.push(`/event/${convenience}`);
   };
   return (
-    <div className="pb-10px rounded-t-[30px] bg-white px-[20px] pt-[27px]">
+    <div>
       <div className="mb-[50px] flex flex-wrap items-start justify-start gap-x-[18px] gap-y-[50px]">
-        {Array.from({ length: 8 }).map((_, i) => (
+        {data?.map((promotion) => (
           <EventItemCard
-            key={i}
+            key={promotion.goodsNo}
             eventItem={{
-              eventType: 'BONUS',
-              imageUrl: pyeonImage,
-              price: 20000,
-              title: 'asdfasdf',
-              convenience: '7Eleven',
+              eventType: promotion.promotionType,
+              imageUrl: promotion.goodsImageUrl,
+              price: promotion.goodsPrice,
+              title: promotion.goodsName,
+              convenience: promotion.storeName,
             }}
           />
         ))}

--- a/apps/web/src/app/main/[category]/HotTrend.tsx
+++ b/apps/web/src/app/main/[category]/HotTrend.tsx
@@ -1,7 +1,7 @@
 import HotTrendCard from '@/components/HotTrendItem';
 import ChevronIcon from '@/components/icons/ChevronIcon';
 
-import { Convenience } from '../../type';
+import { Convenience } from '@/app/type';
 import { mainHotTrendData } from '@/dummy/hotTrend';
 
 interface HotTrendProps {

--- a/apps/web/src/app/main/[category]/HotTrend.tsx
+++ b/apps/web/src/app/main/[category]/HotTrend.tsx
@@ -10,7 +10,7 @@ interface HotTrendProps {
 
 export default function HotTrend({ convenience }: HotTrendProps) {
   return (
-    <div className="rounded-t-[30px] bg-white px-5 pb-10 pt-[27px]">
+    <div>
       <div className="flex flex-wrap items-start justify-start gap-y-5">
         {mainHotTrendData.map((props) => (
           <HotTrendCard key={props.id} {...props} />

--- a/apps/web/src/app/main/[category]/page.tsx
+++ b/apps/web/src/app/main/[category]/page.tsx
@@ -8,6 +8,8 @@ import EventItems from './EventItems';
 import HotTrend from './HotTrend';
 import { CONVENIENCE } from '@/constants/conveniences';
 import { Suspense } from 'react';
+import ApiErrorBoundary from '@/components/ApiErrorBoundary';
+import { useQueryErrorResetBoundary } from '@tanstack/react-query';
 
 interface CategoryPageProps {
   params: { category: Convenience };
@@ -22,6 +24,7 @@ const categoryInfoList = CONVENIENCE.map((convenience) => ({
 export default function CategoryPage({
   params: { category },
 }: CategoryPageProps) {
+  const { reset } = useQueryErrorResetBoundary();
   return (
     <div>
       <div className="sticky top-0 z-30">
@@ -32,9 +35,11 @@ export default function CategoryPage({
       </div>
       <CategoryChildren convenience={category}>
         <HotTrend convenience={category} />
-        <Suspense fallback={<p>Loading...</p>}>
-          <EventItems convenience={category} />
-        </Suspense>
+        <ApiErrorBoundary onReset={reset}>
+          <Suspense fallback={<p>Loading...</p>}>
+            <EventItems convenience={category} />
+          </Suspense>
+        </ApiErrorBoundary>
       </CategoryChildren>
     </div>
   );

--- a/apps/web/src/app/main/[category]/page.tsx
+++ b/apps/web/src/app/main/[category]/page.tsx
@@ -7,6 +7,7 @@ import CategoryChildren from '../CategoryChildren';
 import EventItems from './EventItems';
 import HotTrend from './HotTrend';
 import { CONVENIENCE } from '@/constants/conveniences';
+import httpClient from '@/http/client';
 
 interface CategoryPageProps {
   params: { category: Convenience };

--- a/apps/web/src/app/main/[category]/page.tsx
+++ b/apps/web/src/app/main/[category]/page.tsx
@@ -7,7 +7,7 @@ import CategoryChildren from '../CategoryChildren';
 import EventItems from './EventItems';
 import HotTrend from './HotTrend';
 import { CONVENIENCE } from '@/constants/conveniences';
-import httpClient from '@/http/client';
+import { Suspense } from 'react';
 
 interface CategoryPageProps {
   params: { category: Convenience };
@@ -32,7 +32,9 @@ export default function CategoryPage({
       </div>
       <CategoryChildren convenience={category}>
         <HotTrend convenience={category} />
-        <EventItems convenience={category} />
+        <Suspense fallback={<p>Loading...</p>}>
+          <EventItems convenience={category} />
+        </Suspense>
       </CategoryChildren>
     </div>
   );

--- a/apps/web/src/app/main/[category]/page.tsx
+++ b/apps/web/src/app/main/[category]/page.tsx
@@ -14,9 +14,9 @@ interface CategoryPageProps {
 }
 
 const categoryInfoList = CONVENIENCE.map((convenience) => ({
-  category: convenience,
+  category: convenience.toUpperCase(),
   label: convenience,
-  href: `/main/${convenience}`,
+  href: `/main/${convenience.toUpperCase()}`,
 }));
 
 export default function CategoryPage({

--- a/apps/web/src/app/main/page.tsx
+++ b/apps/web/src/app/main/page.tsx
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export default function HomePage() {
-  redirect('/main/ALL');
-}

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -7,6 +7,8 @@ export default function NotFound() {
   const segmentList = usePathname().split('/');
 
   switch (true) {
+    case segmentList.includes('main'):
+      return redirect('/main/ALL');
     case segmentList.includes('hottrend'):
       return redirect('/hottrend/CU/1');
     case segmentList.includes('event'):

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation';
 
 export default function Home() {
-  redirect('/main');
+  redirect('/main/ALL');
 }

--- a/apps/web/src/app/search/view/SearchResultView.tsx
+++ b/apps/web/src/app/search/view/SearchResultView.tsx
@@ -37,7 +37,7 @@ const SearchResultView = () => {
                 imageUrl: pyeonImage,
                 price: 20000,
                 title: 'asdfasdf',
-                convenience: '7Eleven',
+                convenience: '7ELEVEN',
               }}
             />
           ))}

--- a/apps/web/src/app/search/view/SearchResultView.tsx
+++ b/apps/web/src/app/search/view/SearchResultView.tsx
@@ -11,9 +11,9 @@ const SearchResultView = () => {
   const word = searchParams.get('word');
   const category = searchParams.get('category') as Convenience;
   const categoryInfoList = CONVENIENCE.map((convenience) => ({
-    category: convenience,
+    category: convenience.toUpperCase(),
     label: convenience,
-    href: `/search?word=${word}&category=${convenience}`,
+    href: `/search?word=${word}&category=${convenience.toUpperCase()}`,
   }));
 
   return (

--- a/apps/web/src/app/type.ts
+++ b/apps/web/src/app/type.ts
@@ -1,4 +1,3 @@
-export type Convenience = 'ALL' | 'CU' | 'GS25' | '7Eleven' | 'Emart24';
-export type EventType = 'ONE_PLUS_ONE' | 'TWO_PLUS_ONE' | 'SALE' | 'BONUS';
+export type Convenience = 'ALL' | 'CU' | 'GS25' | '7ELEVEN' | 'EMART24';
 
 export type RecommendationCategory = 'honey' | 'now' | 'situation';

--- a/apps/web/src/app/type.ts
+++ b/apps/web/src/app/type.ts
@@ -1,3 +1,3 @@
 export type Convenience = 'ALL' | 'CU' | 'GS25' | '7ELEVEN' | 'EMART24';
-
+export type EventType = 'ONE_PLUS_ONE' | 'TWO_PLUS_ONE' | 'SALE' | 'BONUS';
 export type RecommendationCategory = 'honey' | 'now' | 'situation';

--- a/apps/web/src/components/ApiErrorBoundary.tsx
+++ b/apps/web/src/components/ApiErrorBoundary.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { ApiError, extractError } from '@/lib/error';
+
+interface ApiErrorBoundaryProps {
+  message?: string;
+  children: React.ReactNode;
+  onReset?: () => void;
+}
+
+interface State {
+  shouldHandleError: boolean;
+  shouldRethrow: boolean;
+  error: ApiError;
+}
+
+const initialState: State = {
+  shouldHandleError: true,
+  shouldRethrow: false,
+  error: null,
+};
+
+class ApiErrorBoundary extends React.Component<ApiErrorBoundaryProps, State> {
+  constructor(props: ApiErrorBoundaryProps) {
+    super(props);
+    this.state = initialState;
+  }
+
+  // 하위 트리에서 throw된 error를 받습니다.
+  // 이 에러는 핸드편 웹에서 사용되는 에러 코드 정보를 담고 있습니다.
+  static getDerivedStateFromError(error: any): State {
+    const apiError = extractError(error);
+    // ApiErrorBoundary에서 처리할 수 없는 에러 코드
+    // 예) 네크워크 에러나 서버 점검 에러 등...
+    if (apiError.status === 404) {
+      return {
+        shouldHandleError: false,
+        // 여기서 처리 할 수 없는 에러라면 render 단계에서 rethrow 하여 상위 에러 바운더리에서 처리하도록 합니다.
+        shouldRethrow: true,
+        error: apiError,
+      };
+    }
+    return {
+      shouldHandleError: true,
+      shouldRethrow: false,
+      error: extractError(error),
+    };
+  }
+
+  resetErrorBoundary() {
+    const { error } = this.state;
+
+    if (error !== null) {
+      this.props.onReset?.();
+      this.setState(initialState);
+    }
+  }
+
+  render() {
+    // 상위 에러 바운더리로 전파
+    if (this.state.shouldRethrow) {
+      throw this.state.error;
+    }
+
+    if (!this.state.shouldHandleError) {
+      return this.props.children;
+    }
+
+    // https://fe-developers.kakaoent.com/2022/221110-error-boundary/
+    if (this.state?.error?.status === 403) {
+      return (
+        <div onClick={() => this.resetErrorBoundary()}>
+          에러가 발생했습니다!
+        </div>
+      );
+    }
+
+    //... if(statue === ??)
+
+    return this.props.children;
+  }
+}
+
+export default ApiErrorBoundary;

--- a/apps/web/src/components/EventItemCard/index.tsx
+++ b/apps/web/src/components/EventItemCard/index.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import Image from 'next/image';
-import { Convenience, EventType } from '@/app/type';
+import { Convenience } from '@/app/type';
 import { formatNumberWithComma } from '@/utils/numberFormatter';
 import { EVENT_TYPE_MAP } from '@/constants/conveniences';
 import Link from 'next/link';
+import { type PromotionType } from '@/apis/type';
 interface EventItem {
-  eventType: EventType;
+  eventType: PromotionType;
   imageUrl: string;
   price: number;
   title: string;

--- a/apps/web/src/components/EventItemCard/index.tsx
+++ b/apps/web/src/components/EventItemCard/index.tsx
@@ -22,7 +22,7 @@ const EventItemCard = ({
 }: Props) => {
   return (
     <div className="w-[calc(50%_-_9px)]">
-      <Link href={'/event/7Eleven/detail/1'}>
+      <Link href={`/event/${convenience}/detail/1`}>
         <div className="mb-[12px] aspect-square w-full rounded-[9px] border-2 border-b-[4px] border-r-[4px] border-black p-[5px]">
           <div className="relative flex h-full w-full items-center justify-center">
             <div

--- a/apps/web/src/components/GlobalErrorBoundary.tsx
+++ b/apps/web/src/components/GlobalErrorBoundary.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { ApiError, extractError } from '@/lib/error';
+
+interface GlobalErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface State {
+  shouldHandleError: boolean;
+  error: ApiError;
+}
+
+const initialState: State = {
+  shouldHandleError: true,
+  error: null,
+};
+
+class GlobalErrorBoundary extends React.Component<
+  GlobalErrorBoundaryProps,
+  State
+> {
+  constructor(props: GlobalErrorBoundaryProps) {
+    super(props);
+    this.state = initialState;
+  }
+  static getDerivedStateFromError(error: Error): State {
+    return {
+      shouldHandleError: true,
+      error: extractError(error),
+    };
+  }
+
+  render() {
+    // if (!this.state.shouldHandleError) {
+    //   return this.props.children;
+    // }
+    console.log('global!!', this.state);
+    if (this.state.error) {
+      return <div>글로벌 에러!!</div>;
+    }
+    return this.props.children;
+  }
+}
+
+export default GlobalErrorBoundary;

--- a/apps/web/src/constants/conveniences.ts
+++ b/apps/web/src/constants/conveniences.ts
@@ -1,13 +1,7 @@
 import { Convenience } from '@/app/type';
 import { EventType } from '@/app/type';
 
-export const CONVENIENCE: Convenience[] = [
-  'ALL',
-  'CU',
-  '7Eleven',
-  'GS25',
-  'Emart24',
-];
+export const CONVENIENCE = ['ALL', 'CU', '7Eleven', 'GS25', 'Emart24'] as const;
 
 export const EVENT_TYPE_LIST = ['1+1', '2+1', '할인', '+덤'];
 

--- a/apps/web/src/constants/conveniences.ts
+++ b/apps/web/src/constants/conveniences.ts
@@ -1,4 +1,3 @@
-import { Convenience } from '@/app/type';
 import { EventType } from '@/app/type';
 
 export const CONVENIENCE = ['ALL', 'CU', '7Eleven', 'GS25', 'Emart24'] as const;

--- a/apps/web/src/dummy/hotTrend.ts
+++ b/apps/web/src/dummy/hotTrend.ts
@@ -32,7 +32,7 @@ export const mainHotTrendData: MainHotTrendInfo[] = [
     imageUrl: '/image/MzE2MTE=.jpg',
     price: 5000,
     title: '혜장라면',
-    convenience: '7Eleven',
+    convenience: '7ELEVEN',
   },
   {
     id: 4,
@@ -40,7 +40,7 @@ export const mainHotTrendData: MainHotTrendInfo[] = [
     imageUrl: '/image/671843.jpg',
     price: 5000,
     title: '빙그레 딸기타임',
-    convenience: 'Emart24',
+    convenience: 'EMART24',
   },
   {
     id: 5,
@@ -107,7 +107,7 @@ export const hotTrendInfoData: HotTrendInfo[] = [
     imageUrl: '/image/MzE2MTE=.jpg',
     price: 5000,
     title: '혜장라면',
-    convenience: '7Eleven',
+    convenience: '7ELEVEN',
   },
   {
     id: 4,
@@ -119,7 +119,7 @@ export const hotTrendInfoData: HotTrendInfo[] = [
     imageUrl: '/image/671843.jpg',
     price: 5000,
     title: '빙그레 딸기타임',
-    convenience: 'Emart24',
+    convenience: 'EMART24',
   },
   {
     id: 5,

--- a/apps/web/src/hooks/query/usePromotion.ts
+++ b/apps/web/src/hooks/query/usePromotion.ts
@@ -16,5 +16,6 @@ export const useGetPromotionGoods = (params: PromotionGoodsParams) => {
   return useQuery({
     queryKey: promotionQueryKey.list(params),
     queryFn: () => getPromotionGoods(params),
+    useErrorBoundary: true,
   });
 };

--- a/apps/web/src/hooks/query/usePromotion.ts
+++ b/apps/web/src/hooks/query/usePromotion.ts
@@ -2,19 +2,19 @@ import { useQuery } from '@tanstack/react-query';
 import { getPromotionGoods } from '@/apis/promotion';
 import { PromotionGoodsParams } from '@/apis/promotion';
 
-const queryKey = {
+export const promotionQueryKey = {
   all: ['promotion'] as const,
-  lists: () => [...queryKey.all, 'list'] as const,
+  lists: () => [...promotionQueryKey.all, 'list'] as const,
   list: (params: PromotionGoodsParams) =>
-    [...queryKey.lists(), params] as const,
-  details: () => [...queryKey.all, 'detail'] as const,
-  detail: (goodsNo: number) => [...queryKey.details(), goodsNo] as const,
+    [...promotionQueryKey.lists(), params] as const,
+  details: () => [...promotionQueryKey.all, 'detail'] as const,
+  detail: (goodsNo: number) =>
+    [...promotionQueryKey.details(), goodsNo] as const,
 };
 
 export const useGetPromotionGoods = (params: PromotionGoodsParams) => {
   return useQuery({
-    queryKey: queryKey.list(params),
+    queryKey: promotionQueryKey.list(params),
     queryFn: () => getPromotionGoods(params),
-    suspense: true,
   });
 };

--- a/apps/web/src/hooks/query/usePromotion.ts
+++ b/apps/web/src/hooks/query/usePromotion.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import { getPromotionGoods } from '@/apis/promotion';
+import { PromotionGoodsParams } from '@/apis/promotion';
+
+const queryKey = {
+  all: ['promotion'] as const,
+  lists: () => [...queryKey.all, 'list'] as const,
+  list: (params: PromotionGoodsParams) =>
+    [...queryKey.lists(), params] as const,
+  details: () => [...queryKey.all, 'detail'] as const,
+  detail: (goodsNo: number) => [...queryKey.details(), goodsNo] as const,
+};
+
+export const useGetPromotionGoods = (params: PromotionGoodsParams) => {
+  return useQuery({
+    queryKey: queryKey.list(params),
+    queryFn: () => getPromotionGoods(params),
+    suspense: true,
+  });
+};

--- a/apps/web/src/http/client.ts
+++ b/apps/web/src/http/client.ts
@@ -1,0 +1,114 @@
+import qs from 'qs';
+
+interface RequestConfig {
+  params?: any;
+  headers?: HeadersInit;
+  signal?: AbortSignal;
+}
+
+export interface HttpClient {
+  baseUrl?: string;
+  get?<T>(
+    url: string,
+    config?: RequestConfig,
+  ): Promise<{ data: T; headers?: Headers }>;
+  post?<T>(
+    url: string,
+    body?: any,
+    config?: RequestConfig,
+  ): Promise<{ data: T; headers?: Headers }>;
+  patch?<T>(
+    url: string,
+    body?: any,
+    config?: RequestConfig,
+  ): Promise<{ data: T; headers?: Headers }>;
+  delete?<T>(
+    url: string,
+    config?: RequestConfig,
+  ): Promise<{ data: T; headers?: Headers }>;
+}
+
+const httpClient: HttpClient = {
+  baseUrl: 'http://api.handpyeon.com',
+  async get<T>(url: string, config: RequestConfig = {}) {
+    const queryString = config?.params
+      ? qs.stringify(config.params, { addQueryPrefix: true })
+      : '';
+
+    // baseAPI()
+    const res = await fetch(this.baseUrl.concat(url, queryString), {
+      method: 'GET',
+      headers: {
+        ...(config?.headers ?? {}),
+      },
+    });
+    const data: T = await res.json();
+
+    const { ok, headers } = res;
+    if (ok) {
+      return { data, headers };
+    }
+    return Promise.reject(data);
+  },
+  async post<T>(url: string, body?: any, config: RequestConfig = {}) {
+    const res = await fetch(this.baseUrl.concat(url), {
+      method: 'POST',
+      headers: {
+        ...(body ? { 'Content-Type': 'application/json' } : {}),
+        ...(config.headers ?? {}),
+      },
+      signal: config.signal,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    const data: T = await res.json();
+
+    const { ok, headers } = res;
+    if (ok) {
+      return { data, headers };
+    }
+    return Promise.reject(data);
+  },
+  async patch<T>(url: string, body: any, config: RequestConfig = {}) {
+    const res = await fetch(this.baseUrl.concat(url), {
+      method: 'PATCH',
+      ...(typeof window === 'undefined' ? {} : { credentials: 'include' }),
+      headers: {
+        ...(body ? { 'Content-Type': 'application/json' } : {}),
+        ...(config.headers ?? {}),
+      },
+      signal: config.signal,
+      body: JSON.stringify(body),
+    });
+
+    const data: T = await res.json();
+
+    const { ok, headers } = res;
+    if (ok) {
+      return { data, headers };
+    }
+    return Promise.reject(data);
+  },
+  async delete<T>(url: string, config: RequestConfig = {}) {
+    const querystring = config?.params
+      ? qs.stringify(config?.params, { addQueryPrefix: true })
+      : '';
+
+    const res = await fetch(this.baseUrl.concat(url, querystring), {
+      method: 'DELETE',
+      headers: {
+        ...(config.headers ?? {}),
+      },
+      signal: config.signal,
+    });
+
+    const data: T = await res.json();
+
+    const { ok, headers } = res;
+    if (ok) {
+      return { data, headers };
+    }
+    return Promise.reject(data);
+  },
+};
+
+export default httpClient;

--- a/apps/web/src/lib/error.ts
+++ b/apps/web/src/lib/error.ts
@@ -1,0 +1,24 @@
+export function isApiError(e: any): e is ApiError {
+  return (
+    e?.error !== undefined && e?.status !== undefined && e?.path !== undefined
+  );
+}
+
+export interface ApiError {
+  error: string;
+  path: string;
+  status: number;
+  timestamp: string;
+}
+
+export function extractError(e: any): ApiError {
+  if (isApiError(e)) {
+    return e;
+  }
+  return {
+    error: 'unkown error',
+    path: 'unkown',
+    status: 500,
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/apps/web/src/store/tabBar.ts
+++ b/apps/web/src/store/tabBar.ts
@@ -15,8 +15,8 @@ const initTabState: TabBarIndexs = {
   ALL: 0,
   CU: 0,
   GS25: 0,
-  '7Eleven': 0,
-  Emart24: 0,
+  '7ELEVEN': 0,
+  EMART24: 0,
 };
 
 export const createTabBarSlice: StateCreatorDevTool<TabBarSlice> = devtools(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3021,6 +3021,35 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
+"@tanstack/match-sorter-utils@^8.7.0":
+  version "8.8.4"
+  resolved "https://registry.yarnpkg.com/@tanstack/match-sorter-utils/-/match-sorter-utils-8.8.4.tgz#0b2864d8b7bac06a9f84cb903d405852cc40a457"
+  integrity sha512-rKH8LjZiszWEvmi01NR72QWZ8m4xmXre0OOwlRGnjU01Eqz/QnN+cqpty2PJ0efHblq09+KilvyR7lsbzmXVEw==
+  dependencies:
+    remove-accents "0.4.2"
+
+"@tanstack/query-core@4.29.19":
+  version "4.29.19"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-4.29.19.tgz#49ccbd0606633d1e55baf3b91ab7cc7aef411b1d"
+  integrity sha512-uPe1DukeIpIHpQi6UzIgBcXsjjsDaLnc7hF+zLBKnaUlh7jFE/A+P8t4cU4VzKPMFB/C970n/9SxtpO5hmIRgw==
+
+"@tanstack/react-query-devtools@^4.29.19":
+  version "4.29.19"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query-devtools/-/react-query-devtools-4.29.19.tgz#b6f337c91313388d3f04c890449005d7bb355322"
+  integrity sha512-rL2xqTPr+7gJvVGwyq8E8CWqqw950N4lZ6ffJeNX0qqymKHxHW1FM6nZaYt7Aufs/bXH0m1L9Sj3kDGQbp0rwg==
+  dependencies:
+    "@tanstack/match-sorter-utils" "^8.7.0"
+    superjson "^1.10.0"
+    use-sync-external-store "^1.2.0"
+
+"@tanstack/react-query@^4.29.19":
+  version "4.29.19"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-4.29.19.tgz#6ba187f2d0ea36ae83ff1f67068f53c88ce7b228"
+  integrity sha512-XiTIOHHQ5Cw1WUlHaD4fmVUMhoWjuNJlAeJGq7eM4BraI5z7y8WkZO+NR8PSuRnQGblpuVdjClQbDFtwxTtTUw==
+  dependencies:
+    "@tanstack/query-core" "4.29.19"
+    use-sync-external-store "^1.2.0"
+
 "@testing-library/dom@^8.3.0":
   version "8.20.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.20.0.tgz#914aa862cef0f5e89b98cc48e3445c4c921010f6"
@@ -4627,6 +4656,13 @@ cookie@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
+
+copy-anything@^3.0.2:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/copy-anything/-/copy-anything-3.0.5.tgz#2d92dce8c498f790fa7ad16b01a1ae5a45b020a0"
+  integrity sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==
+  dependencies:
+    is-what "^4.1.8"
 
 core-js-compat@^3.25.1:
   version "3.30.2"
@@ -6712,6 +6748,11 @@ is-weakset@^2.0.1:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
 
+is-what@^4.1.8:
+  version "4.1.15"
+  resolved "https://registry.yarnpkg.com/is-what/-/is-what-4.1.15.tgz#de43a81090417a425942d67b1ae86e7fae2eee0e"
+  integrity sha512-uKua1wfy3Yt+YqsD6mTUEa2zSi3G1oPlqTflgaPJ7z63vUGN5pxFpnQfeSLMFnJDEsdvOtkp1rUWkYjB4YfhgA==
+
 is-wsl@^2.1.1, is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz"
@@ -8707,6 +8748,11 @@ remark-slug@^6.0.0:
     mdast-util-to-string "^1.0.0"
     unist-util-visit "^2.0.0"
 
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -9389,6 +9435,13 @@ sucrase@^3.20.3, sucrase@^3.32.0:
     pirates "^4.0.1"
     ts-interface-checker "^0.1.9"
 
+superjson@^1.10.0:
+  version "1.12.4"
+  resolved "https://registry.yarnpkg.com/superjson/-/superjson-1.12.4.tgz#cfea35b0d1eb0f12d8b185f1d871272555f5a61f"
+  integrity sha512-vkpPQAxdCg9SLfPv5GPC5fnGrui/WryktoN9O5+Zif/14QIMjw+RITf/5LbBh+9QpBFb3KNvJth+puz2H8o6GQ==
+  dependencies:
+    copy-anything "^3.0.2"
+
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz"
@@ -9995,7 +10048,7 @@ use-resize-observer@^9.1.0:
   dependencies:
     "@juggle/resize-observer" "^3.3.1"
 
-use-sync-external-store@1.2.0:
+use-sync-external-store@1.2.0, use-sync-external-store@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
   integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==


### PR DESCRIPTION
## 한 줄 요약
- 서버 api 연동을 위한 템플릿 작업

## 자세한 내용
- `apis/type.ts`에서 서버 response에 대한 타입 정의
- root페이지 진입시 `main/ALL` 페이지로 바로 리다이렉트
- Suspense쪽의 fallback ui는 추후 수정 예정
- 기존의 Emart24 , 7Eleven 상수를 서버 enum에 맞게 EMART24,7ELEVEN으로 변경
- 선언적으로 에러처리를 위해 error boundary 추가. [참고글](https://fe-developers.kakaoent.com/2022/221110-error-boundary/)
    - 코드상의 error status는 예시를 위해서 작성했습니다.서버분들에게 여쭤 본 후 맞춰나가면 될 거 같습니다.