### PR TITLE
feat(web) : 핫트렌드 API 연동 - Draft 

### DIFF
--- a/apps/web/src/apis/hotTrend.ts
+++ b/apps/web/src/apis/hotTrend.ts
@@ -1,0 +1,15 @@
+import httpClient from '@/http/client';
+
+import { HotTrendCategory, HotTrendGoods } from './type';
+
+export const getHotTrendGoods = async (params: HotTrendCategory) => {
+  const { data } = await httpClient.get<{ data: HotTrendGoods[] }>(
+    '/handpyeon/api/hotTrends',
+    {
+      params: {
+        type: params,
+      },
+    },
+  );
+  return data.data;
+};

--- a/apps/web/src/apis/promotion.ts
+++ b/apps/web/src/apis/promotion.ts
@@ -1,7 +1,7 @@
 import httpClient from '@/http/client';
-import type { storeName, PromotionGoods } from './type';
+import type { StoreName, PromotionGoods } from './type';
 
-export type PromotionGoodsParams = storeName | 'ALL';
+export type PromotionGoodsParams = StoreName | 'ALL';
 
 export const getPromotionGoods = async (params: PromotionGoodsParams) => {
   const { data } = await httpClient.get<{ data: PromotionGoods[] }>(

--- a/apps/web/src/apis/recommendation.ts
+++ b/apps/web/src/apis/recommendation.ts
@@ -1,0 +1,14 @@
+import httpClient from '@/http/client';
+
+import { RecommendationBanner } from './type';
+
+export const getRecommendationBanners = async () => {
+  const { data } = await httpClient.get<{ data: RecommendationBanner[] }>(
+    '/handpyeon/api/banners/recommend',
+  );
+
+  return data.data.map(({ bannerImage, contentsNumber }) => ({
+    src: bannerImage,
+    url: `/recommendation/contents/${contentsNumber}`,
+  }));
+};

--- a/apps/web/src/apis/type.ts
+++ b/apps/web/src/apis/type.ts
@@ -1,4 +1,4 @@
-export type storeName = 'CU' | 'GS25' | '7ELEVEN' | 'EMART24';
+export type StoreName = 'CU' | 'GS25' | '7ELEVEN' | 'EMART24';
 export type PromotionType =
   | 'ONE_PLUS_ONE'
   | 'TWO_PLUS_ONE'
@@ -14,5 +14,5 @@ export interface PromotionGoods {
   goodsPrice: number;
   goodsImageUrl: string;
   promotionType: PromotionType;
-  storeName: storeName;
+  storeName: StoreName;
 }

--- a/apps/web/src/apis/type.ts
+++ b/apps/web/src/apis/type.ts
@@ -25,3 +25,8 @@ export interface HotTrendGoods {
   goodsPrice: number;
   goodsImageUrl: string;
 }
+
+export interface RecommendationBanner {
+  bannerImage: string;
+  contentsNumber: number;
+}

--- a/apps/web/src/apis/type.ts
+++ b/apps/web/src/apis/type.ts
@@ -16,3 +16,12 @@ export interface PromotionGoods {
   promotionType: PromotionType;
   storeName: StoreName;
 }
+export type HotTrendCategory = StoreName | 'ALL';
+
+export interface HotTrendGoods {
+  rank: number;
+  storeName: StoreName;
+  goodsName: string;
+  goodsPrice: number;
+  goodsImageUrl: string;
+}

--- a/apps/web/src/app/hottrend/[category]/[rank]/HotTrendInfo.tsx
+++ b/apps/web/src/app/hottrend/[category]/[rank]/HotTrendInfo.tsx
@@ -8,13 +8,13 @@ import { hotTrendInfoData } from '@/dummy/hotTrend';
 import { formatNumberWithComma, prefixZero } from '@/utils/numberFormatter';
 
 interface HotTrendInfoProps {
-  convenience: Convenience;
+  category: Convenience;
   rank: number;
 }
 
-export default function HotTrendInfo({ convenience, rank }: HotTrendInfoProps) {
+export default function HotTrendInfo({ category, rank }: HotTrendInfoProps) {
   const info = hotTrendInfoData.find(
-    (data) => data.rank === Number(rank) && data.convenience === convenience,
+    (data) => data.rank === Number(rank) && data.storeName === category,
   );
 
   return (
@@ -34,16 +34,16 @@ export default function HotTrendInfo({ convenience, rank }: HotTrendInfoProps) {
               {info.hottrendTitle}
             </div>
             <div className="border-main1 px-17px py-4px border-t-2 font-medium">
-              <div>{info.title}</div>
-              <div>{formatNumberWithComma(info.price)}원</div>
+              <div>{info.goodsName}</div>
+              <div>{formatNumberWithComma(info.goodsPrice)}원</div>
             </div>
           </div>
           <div className="border-main1 min-w-[152px] border-l-2 p-2">
             <div className="relative flex h-full w-full ">
               <Image
                 className="object-contain"
-                src={info.imageUrl}
-                alt={info.title}
+                src={info.goodsImageUrl}
+                alt={info.goodsName}
                 fill
               />
             </div>

--- a/apps/web/src/app/hottrend/[category]/[rank]/HotTrendRankList.tsx
+++ b/apps/web/src/app/hottrend/[category]/[rank]/HotTrendRankList.tsx
@@ -8,7 +8,7 @@ interface HotTrendRankListProps {
 
 export default function HotTrendRankList({ category }: HotTrendRankListProps) {
   const hotTrendData = mainHotTrendData.filter(
-    (one) => one.convenience === category,
+    (one) => one.storeName === category,
   );
 
   return (

--- a/apps/web/src/app/hottrend/[category]/[rank]/page.tsx
+++ b/apps/web/src/app/hottrend/[category]/[rank]/page.tsx
@@ -12,7 +12,7 @@ export default function HotTrendCategoryRankInfoPage({
 }: CategoryPageProps) {
   return (
     <>
-      <HotTrendInfo convenience={category} rank={rank} />
+      <HotTrendInfo category={category} rank={rank} />
       <HotTrendRankList category={category} />
     </>
   );

--- a/apps/web/src/app/main/[category]/EventItems.tsx
+++ b/apps/web/src/app/main/[category]/EventItems.tsx
@@ -19,9 +19,9 @@ export default function EventItems({ convenience }: EventItemsProps) {
   return (
     <div>
       <div className="mb-[50px] flex flex-wrap items-start justify-start gap-x-[18px] gap-y-[50px]">
-        {data?.map((promotion) => (
+        {data?.map((promotion, idx) => (
           <EventItemCard
-            key={promotion.goodsNo}
+            key={`${idx}-${promotion.goodsNo}`}
             eventItem={{
               eventType: promotion.promotionType,
               imageUrl: promotion.goodsImageUrl,

--- a/apps/web/src/app/main/[category]/HotTrend.tsx
+++ b/apps/web/src/app/main/[category]/HotTrend.tsx
@@ -1,19 +1,18 @@
+import { HotTrendCategory } from '@/apis/type';
 import HotTrendCard from '@/components/HotTrendItem';
 import ChevronIcon from '@/components/icons/ChevronIcon';
-
-import { Convenience } from '@/app/type';
 import { mainHotTrendData } from '@/dummy/hotTrend';
 
 interface HotTrendProps {
-  convenience: Convenience;
+  convenience: HotTrendCategory;
 }
 
 export default function HotTrend({ convenience }: HotTrendProps) {
   return (
     <div>
       <div className="flex flex-wrap items-start justify-start gap-y-5">
-        {mainHotTrendData.map((props) => (
-          <HotTrendCard key={props.id} {...props} />
+        {mainHotTrendData.map((props, idx) => (
+          <HotTrendCard key={`${idx}-${props.goodsName}`} {...props} />
         ))}
       </div>
       <div className="mt-10">

--- a/apps/web/src/app/main/[category]/HotTrend.tsx
+++ b/apps/web/src/app/main/[category]/HotTrend.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 import { HotTrendCategory } from '@/apis/type';
 import HotTrendCard from '@/components/HotTrendItem';
 import ChevronIcon from '@/components/icons/ChevronIcon';
@@ -6,6 +8,14 @@ import { useGetHotTrendGoods } from '@/hooks/query/useHotTrends';
 interface HotTrendProps {
   convenience: HotTrendCategory;
 }
+
+const mappingSegments: Record<HotTrendCategory, string> = {
+  ALL: 'CU',
+  CU: 'CU',
+  GS25: 'GS25',
+  '7ELEVEN': '7ELEVEN',
+  EMART24: 'EMART24',
+};
 
 export default function HotTrend({ convenience }: HotTrendProps) {
   const { data } = useGetHotTrendGoods(convenience);
@@ -18,12 +28,15 @@ export default function HotTrend({ convenience }: HotTrendProps) {
         ))}
       </div>
       <div className="mt-10">
-        <button className="w-full rounded-[7px] bg-[#1E1C1C] py-3 text-white">
+        <Link
+          href={`/hottrend/${mappingSegments[convenience]}/1`}
+          className="block w-full rounded-[7px] bg-[#1E1C1C] py-3 text-white"
+        >
           <span className="flex items-center justify-center gap-1">
             더보기
             <ChevronIcon />
           </span>
-        </button>
+        </Link>
       </div>
     </div>
   );

--- a/apps/web/src/app/main/[category]/HotTrend.tsx
+++ b/apps/web/src/app/main/[category]/HotTrend.tsx
@@ -1,17 +1,19 @@
 import { HotTrendCategory } from '@/apis/type';
 import HotTrendCard from '@/components/HotTrendItem';
 import ChevronIcon from '@/components/icons/ChevronIcon';
-import { mainHotTrendData } from '@/dummy/hotTrend';
+import { useGetHotTrendGoods } from '@/hooks/query/useHotTrends';
 
 interface HotTrendProps {
   convenience: HotTrendCategory;
 }
 
 export default function HotTrend({ convenience }: HotTrendProps) {
+  const { data } = useGetHotTrendGoods(convenience);
+
   return (
     <div>
       <div className="flex flex-wrap items-start justify-start gap-y-5">
-        {mainHotTrendData.map((props, idx) => (
+        {data?.map((props, idx) => (
           <HotTrendCard key={`${idx}-${props.goodsName}`} {...props} />
         ))}
       </div>

--- a/apps/web/src/app/main/[category]/page.tsx
+++ b/apps/web/src/app/main/[category]/page.tsx
@@ -1,15 +1,17 @@
 'use client';
 
+import { Suspense } from 'react';
+
 import { Convenience } from '@/app/type';
+import ApiErrorBoundary from '@/components/ApiErrorBoundary';
+import Loading from '@/components/Loading';
 import TabCategory from '@/components/TabCategory';
+import { CONVENIENCE } from '@/constants/conveniences';
+import { useQueryErrorResetBoundary } from '@tanstack/react-query';
 
 import CategoryChildren from '../CategoryChildren';
 import EventItems from './EventItems';
 import HotTrend from './HotTrend';
-import { CONVENIENCE } from '@/constants/conveniences';
-import { Suspense } from 'react';
-import ApiErrorBoundary from '@/components/ApiErrorBoundary';
-import { useQueryErrorResetBoundary } from '@tanstack/react-query';
 
 interface CategoryPageProps {
   params: { category: Convenience };
@@ -34,9 +36,13 @@ export default function CategoryPage({
         />
       </div>
       <CategoryChildren convenience={category}>
-        <HotTrend convenience={category} />
         <ApiErrorBoundary onReset={reset}>
-          <Suspense fallback={<p>Loading...</p>}>
+          <Suspense fallback={<Loading />}>
+            <HotTrend convenience={category} />
+          </Suspense>
+        </ApiErrorBoundary>
+        <ApiErrorBoundary onReset={reset}>
+          <Suspense fallback={<Loading />}>
             <EventItems convenience={category} />
           </Suspense>
         </ApiErrorBoundary>

--- a/apps/web/src/app/main/layout.tsx
+++ b/apps/web/src/app/main/layout.tsx
@@ -1,17 +1,25 @@
-import BannerSlides, { BannerInfo } from '@/components/BannerSlides';
-import { BANNER_DATA } from '@/constants/assets';
+import { Suspense } from 'react';
+
+import { getRecommendationBanners } from '@/apis/recommendation';
+import BannerSlides from '@/components/BannerSlides';
+import Loading from '@/components/Loading';
+
 import Header from './Header';
 
 interface HomeLayoutProps {
   children: React.ReactNode;
 }
 
-export default function HomeLayout({ children }: HomeLayoutProps) {
+export default async function HomeLayout({ children }: HomeLayoutProps) {
+  const data = await getRecommendationBanners();
+
   return (
     <div className="flex-1">
       <Header />
       <div className="h-[178px]">
-        <BannerSlides data={BANNER_DATA} totalViewURL="/recommendation" />
+        <Suspense fallback={<Loading />}>
+          <BannerSlides data={data} totalViewURL="/recommendation" />
+        </Suspense>
       </div>
       <div>{children}</div>
     </div>

--- a/apps/web/src/components/GlobalErrorBoundary.tsx
+++ b/apps/web/src/components/GlobalErrorBoundary.tsx
@@ -31,10 +31,6 @@ class GlobalErrorBoundary extends React.Component<
   }
 
   render() {
-    // if (!this.state.shouldHandleError) {
-    //   return this.props.children;
-    // }
-    console.log('global!!', this.state);
     if (this.state.error) {
       return <div>글로벌 에러!!</div>;
     }

--- a/apps/web/src/components/HotTrendItem/index.tsx
+++ b/apps/web/src/components/HotTrendItem/index.tsx
@@ -1,52 +1,44 @@
 import Image from 'next/image';
 import Link from 'next/link';
 
-import { Convenience } from '@/app/type';
+import { HotTrendGoods } from '@/apis/type';
 import RankBox from '@/components/RankBox';
 import { formatNumberWithComma } from '@/utils/numberFormatter';
 
-interface HotTrendCardProps {
-  id: string | number;
-  rank: number;
-  imageUrl: string;
-  price: number;
-  title: string;
-  convenience: Convenience;
-}
+interface HotTrendCardProps extends HotTrendGoods {}
 
 export default function HotTrendCard({
-  id,
   rank,
-  imageUrl,
-  price,
-  title,
-  convenience,
+  storeName,
+  goodsName,
+  goodsPrice,
+  goodsImageUrl,
 }: HotTrendCardProps) {
   return (
     <div className="min-h-[165px]  w-full">
-      <Link className="relative" href={`/hottrend/${convenience}/${rank}`}>
+      <Link className="relative" href={`/hottrend/${storeName}/${rank}`}>
         <div className="border-main1 bg-main1 absolute left-[2px] top-[1px] h-full w-[calc(100%+3px)] rounded-[9px] border-2"></div>
         <div className="p-10px relative  flex h-[165px] rounded-[9px] border-2 border-[#1E1C1C]  bg-white">
           <div className="relative my-2 ml-[27px] flex-1">
             <Image
               className="object-contain"
-              src={imageUrl}
+              src={goodsImageUrl}
               fill
-              alt={`hottrend-${title}`}
+              alt={`hottrend-${goodsName}`}
             />
           </div>
           <div className="mt-[46px] w-[168px]">
             <div>
               <span className="px-7px py-2px rounded-sm border-[1px]  border-[#1E1C1C]  font-bold leading-none">
-                {convenience}
+                {storeName}
               </span>
             </div>
             <div className="mt-[11px] truncate text-base font-medium	leading-none">
-              {title}
+              {goodsName}
             </div>
             <div className="mt-[2px] leading-none">
               <span className="text-xl2 font-bold ">
-                {formatNumberWithComma(price)}
+                {formatNumberWithComma(goodsPrice)}
               </span>
               <span>원</span>
             </div>

--- a/apps/web/src/components/Loading/index.tsx
+++ b/apps/web/src/components/Loading/index.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p>Loading...</p>;
+}

--- a/apps/web/src/dummy/hotTrend.ts
+++ b/apps/web/src/dummy/hotTrend.ts
@@ -1,75 +1,77 @@
-import { Convenience } from '@/app/type';
+import { StoreName } from '@/apis/type';
 
 type MainHotTrendInfo = {
   id: string | number;
   rank: number;
-  imageUrl: string;
-  price: number;
-  title: string;
-  convenience: Convenience;
+  goodsImageUrl: string;
+  goodsPrice: number;
+  goodsName: string;
+  storeName: StoreName;
 };
 
 export const mainHotTrendData: MainHotTrendInfo[] = [
   {
     id: 1,
     rank: 1,
-    imageUrl: '/image/8809196615577.jpg',
-    price: 5000,
-    title: '백종원의 연탄불고기',
-    convenience: 'CU',
+    goodsImageUrl: '/image/8809196615577.jpg',
+    goodsPrice: 5000,
+    goodsName: '백종원의 연탄불고기',
+    storeName: 'CU',
   },
   {
     id: 2,
     rank: 1,
-    imageUrl: '/image/8801007423180.jpg',
-    price: 5000,
-    title: '햇반컵반 강된장 보리비빔밥',
-    convenience: 'GS25',
+    goodsImageUrl: '/image/8801007423180.jpg',
+    goodsPrice: 5000,
+    goodsName: '햇반컵반 강된장 보리비빔밥',
+    storeName: 'GS25',
   },
   {
     id: 3,
     rank: 1,
-    imageUrl: '/image/MzE2MTE=.jpg',
-    price: 5000,
-    title: '혜장라면',
-    convenience: '7ELEVEN',
+    goodsImageUrl: '/image/MzE2MTE=.jpg',
+    goodsPrice: 5000,
+    goodsName: '혜장라면',
+    storeName: '7ELEVEN',
   },
   {
     id: 4,
     rank: 1,
-    imageUrl: '/image/671843.jpg',
-    price: 5000,
-    title: '빙그레 딸기타임',
-    convenience: 'EMART24',
+    goodsImageUrl: '/image/671843.jpg',
+    goodsPrice: 5000,
+    goodsName: '빙그레 딸기타임',
+    storeName: 'EMART24',
   },
   {
     id: 5,
     rank: 2,
-    imageUrl: '/image/GD_2800100153426_001.jpg',
-    price: 5000,
-    title: '캐나다 한끼스테이크',
-    convenience: 'CU',
+    goodsImageUrl: '/image/GD_2800100153426_001.jpg',
+    goodsPrice: 5000,
+    goodsName: '캐나다 한끼스테이크',
+    storeName: 'CU',
   },
   {
     id: 6,
     rank: 2,
-    imageUrl: '/image/GD_8801056150013_007.jpg',
-    price: 5000,
-    title: '펩시 500ml 캔',
-    convenience: 'GS25',
+    goodsImageUrl: '/image/GD_8801056150013_007.jpg',
+    goodsPrice: 5000,
+    goodsName: '펩시 500ml 캔',
+    storeName: 'GS25',
   },
 ];
 
 type HotTrendInfo = {
   id: string | number;
   rank: number;
-  imageUrl: string;
-  price: number;
-  title: string;
-  convenience: Convenience;
+
   hottrendTitle: string;
   hottrendContent: string;
   moreUrl?: string;
+
+  goodsImageUrl: string;
+  goodsPrice: number;
+  goodsName: string;
+  storeName: StoreName;
 };
 
 export const hotTrendInfoData: HotTrendInfo[] = [
@@ -80,10 +82,10 @@ export const hotTrendInfoData: HotTrendInfo[] = [
     hottrendContent:
       '캔뚜껑이 완전히 열려서 구름 같은 맥주거품이 쌓이는 재미가 포인트!',
     moreUrl: '',
-    imageUrl: '/image/8809196615577.jpg',
-    price: 5000,
-    title: '백종원의 연탄불고기',
-    convenience: 'CU',
+    goodsImageUrl: '/image/8809196615577.jpg',
+    goodsPrice: 5000,
+    goodsName: '백종원의 연탄불고기',
+    storeName: 'CU',
   },
   {
     id: 2,
@@ -92,10 +94,10 @@ export const hotTrendInfoData: HotTrendInfo[] = [
     hottrendContent:
       '캔뚜껑이 완전히 열려서 구름 같은 맥주거품이 쌓이는 재미가 포인트!',
     moreUrl: '',
-    imageUrl: '/image/8801007423180.jpg',
-    price: 5000,
-    title: '햇반컵반 강된장 보리비빔밥',
-    convenience: 'GS25',
+    goodsImageUrl: '/image/8801007423180.jpg',
+    goodsPrice: 5000,
+    goodsName: '햇반컵반 강된장 보리비빔밥',
+    storeName: 'GS25',
   },
   {
     id: 3,
@@ -104,10 +106,10 @@ export const hotTrendInfoData: HotTrendInfo[] = [
     hottrendContent:
       '캔뚜껑이 완전히 열려서 구름 같은 맥주거품이 쌓이는 재미가 포인트!',
     moreUrl: '',
-    imageUrl: '/image/MzE2MTE=.jpg',
-    price: 5000,
-    title: '혜장라면',
-    convenience: '7ELEVEN',
+    goodsImageUrl: '/image/MzE2MTE=.jpg',
+    goodsPrice: 5000,
+    goodsName: '혜장라면',
+    storeName: '7ELEVEN',
   },
   {
     id: 4,
@@ -116,10 +118,10 @@ export const hotTrendInfoData: HotTrendInfo[] = [
     hottrendContent:
       '캔뚜껑이 완전히 열려서 구름 같은 맥주거품이 쌓이는 재미가 포인트!',
     moreUrl: '',
-    imageUrl: '/image/671843.jpg',
-    price: 5000,
-    title: '빙그레 딸기타임',
-    convenience: 'EMART24',
+    goodsImageUrl: '/image/671843.jpg',
+    goodsPrice: 5000,
+    goodsName: '빙그레 딸기타임',
+    storeName: 'EMART24',
   },
   {
     id: 5,
@@ -128,10 +130,10 @@ export const hotTrendInfoData: HotTrendInfo[] = [
     hottrendContent:
       '캔뚜껑이 완전히 열려서 구름 같은 맥주거품이 쌓이는 재미가 포인트!',
     moreUrl: '',
-    imageUrl: '/image/GD_2800100153426_001.jpg',
-    price: 5000,
-    title: '캐나다 한끼스테이크',
-    convenience: 'CU',
+    goodsImageUrl: '/image/GD_2800100153426_001.jpg',
+    goodsPrice: 5000,
+    goodsName: '캐나다 한끼스테이크',
+    storeName: 'CU',
   },
   {
     id: 6,
@@ -140,9 +142,9 @@ export const hotTrendInfoData: HotTrendInfo[] = [
     hottrendContent:
       '캔뚜껑이 완전히 열려서 구름 같은 맥주거품이 쌓이는 재미가 포인트!',
     moreUrl: '',
-    imageUrl: '/image/GD_8801056150013_007.jpg',
-    price: 5000,
-    title: '펩시 500ml 캔',
-    convenience: 'GS25',
+    goodsImageUrl: '/image/GD_8801056150013_007.jpg',
+    goodsPrice: 5000,
+    goodsName: '펩시 500ml 캔',
+    storeName: 'GS25',
   },
 ];

--- a/apps/web/src/hooks/query/useHotTrends.ts
+++ b/apps/web/src/hooks/query/useHotTrends.ts
@@ -1,0 +1,16 @@
+import { getHotTrendGoods } from '@/apis/hotTrend';
+import { HotTrendCategory } from '@/apis/type';
+import { useQuery } from '@tanstack/react-query';
+
+const queryKeyHotTrend = ['hotTrend'] as const;
+const queryKeyHotTrendList = (category: HotTrendCategory) =>
+  [...queryKeyHotTrend, 'list', category] as const;
+
+export const useGetHotTrendGoods = (categoryName: HotTrendCategory) => {
+  return useQuery({
+    queryKey: queryKeyHotTrendList(categoryName),
+    queryFn: () => getHotTrendGoods(categoryName),
+    suspense: true,
+    useErrorBoundary: true,
+  });
+};


### PR DESCRIPTION
## 한 줄 요약
메인 페이지 핫트렌드, 추천콘텐츠 배너 API 연동 

## 자세한 내용


### 메인페이지 > 추천 컨텐츠 배너

- 추천컨텐츠 배너 조회 API [GET: /handpyeon/api/banners/recommend](http://api.handpyeon.com/swagger-ui/index.html#/Handpyeon%20API/getRecommendedBanners)
- 서버 컴포넌트인 Layout 안에 존재해서 바로 `getRecommendationBanners` 요청 처리 

### 메인페잊 > 핫 트렌드 목록
- 핫 트렌드 목록 조회 API [GET : /handpyeon/api/hotTrends](http://api.handpyeon.com/swagger-ui/index.html#/Handpyeon%20API/getHotTrends)
- `useGetHotTrendGoods` 추가 및 이용 
