### PR TITLE
feat(web): 행사상품 리스트 api 연결

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -16,6 +16,18 @@ const nextConfig = {
         port: '',
         pathname: '/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'image.woodongs.com',
+        port: '',
+        pathname: '/**',
+      },
+      {
+        protocol: 'http',
+        hostname: 'www.emart24.co.kr',
+        port: '',
+        pathname: '/**',
+      },
     ],
   },
 };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
     "next": "13.4.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-intersection-observer": "^9.5.2",
     "swiper": "^9.4.1",
     "ui": "*",
     "zustand": "^4.3.8"

--- a/apps/web/src/apis/promotion.ts
+++ b/apps/web/src/apis/promotion.ts
@@ -1,8 +1,13 @@
 import httpClient from '@/http/client';
-import type { PromotionGoods, PromotionGoodsCategory } from './type';
+import type {
+  PromotionGoods,
+  PromotionGoodsCategory,
+  PromotionType,
+} from './type';
 
 export interface PromotionGoodsParams {
   type: PromotionGoodsCategory;
+  promotionType?: PromotionType;
   keyword?: string;
   cursor?: number;
 }

--- a/apps/web/src/apis/promotion.ts
+++ b/apps/web/src/apis/promotion.ts
@@ -1,15 +1,17 @@
 import httpClient from '@/http/client';
 import type { PromotionGoods, PromotionGoodsCategory } from './type';
 
-export type PromotionGoodsParams = PromotionGoodsCategory;
+export interface PromotionGoodsParams {
+  type: PromotionGoodsCategory;
+  keyword?: string;
+  cursor?: number;
+}
 
 export const getPromotionGoods = async (params: PromotionGoodsParams) => {
   const { data } = await httpClient.get<{ data: PromotionGoods[] }>(
     '/handpyeon/api/promotionGoods',
     {
-      params: {
-        type: params,
-      },
+      params,
     },
   );
   return data.data;

--- a/apps/web/src/apis/promotion.ts
+++ b/apps/web/src/apis/promotion.ts
@@ -25,6 +25,5 @@ export const getPromotionGoodsList = async (params: PromotionGoodsParams) => {
     data,
     pageInfo,
     nextCursor: params.cursor + 1,
-    currentPage: params.cursor,
   };
 };

--- a/apps/web/src/apis/promotion.ts
+++ b/apps/web/src/apis/promotion.ts
@@ -1,7 +1,7 @@
 import httpClient from '@/http/client';
 import type {
-  PromotionGoods,
   PromotionGoodsCategory,
+  PromotionGoodsList,
   PromotionType,
 } from './type';
 
@@ -12,12 +12,19 @@ export interface PromotionGoodsParams {
   cursor?: number;
 }
 
-export const getPromotionGoods = async (params: PromotionGoodsParams) => {
-  const { data } = await httpClient.get<{ data: PromotionGoods[] }>(
+export const getPromotionGoodsList = async (params: PromotionGoodsParams) => {
+  const {
+    data: { data, pageInfo },
+  } = await httpClient.get<PromotionGoodsList>(
     '/handpyeon/api/promotionGoods',
     {
       params,
     },
   );
-  return data.data;
+  return {
+    data,
+    pageInfo,
+    nextCursor: params.cursor + 1,
+    currentPage: params.cursor,
+  };
 };

--- a/apps/web/src/apis/type.ts
+++ b/apps/web/src/apis/type.ts
@@ -17,6 +17,13 @@ export interface PromotionGoods {
   promotionType: PromotionType;
   storeName: StoreName;
 }
+export interface PromotionGoodsList {
+  data: PromotionGoods[];
+  pageInfo: {
+    totalElements: number;
+    totalPages: number;
+  };
+}
 
 export type HotTrendCategory = StoreName | 'ALL';
 

--- a/apps/web/src/app/event/[category]/components/EventItemSection.tsx
+++ b/apps/web/src/app/event/[category]/components/EventItemSection.tsx
@@ -1,11 +1,19 @@
 'use client';
+import { type Convenience } from '@/app/type';
 import Chip from '@/components/Chip';
-import EventItemCard from '@/components/EventItemCard';
 import { EVENT_TYPE_LIST } from '@/constants/conveniences';
-import { pyeonImage } from '@/dummy/image';
-import React from 'react';
+import React, { Suspense } from 'react';
+import EventItems from './EventItems';
+import { useQueryErrorResetBoundary } from '@tanstack/react-query';
+import ApiErrorBoundary from '@/components/ApiErrorBoundary';
+import LoadingIndicator from '@/components/LoadingIndicator';
 
-const EventItemSection = () => {
+interface EventItemSectionProps {
+  category: Convenience;
+}
+
+const EventItemSection = ({ category }: EventItemSectionProps) => {
+  const { reset } = useQueryErrorResetBoundary();
   return (
     <div className="px-[20px]">
       <div className="pb-[18px] pt-[40px]">
@@ -24,20 +32,11 @@ const EventItemSection = () => {
           ))}
         </Chip>
       </div>
-      <div className="flex flex-wrap items-start justify-start gap-x-[18px] gap-y-[50px]">
-        {Array.from({ length: 8 }).map((_, i) => (
-          <EventItemCard
-            key={i}
-            eventItem={{
-              eventType: 'ONE_PLUS_ONE',
-              imageUrl: pyeonImage,
-              price: 20000,
-              title: 'asdfasdf',
-              convenience: '7Eleven',
-            }}
-          />
-        ))}
-      </div>
+      <ApiErrorBoundary onReset={reset}>
+        <Suspense fallback={<LoadingIndicator />}>
+          <EventItems category={category} />
+        </Suspense>
+      </ApiErrorBoundary>
     </div>
   );
 };

--- a/apps/web/src/app/event/[category]/components/EventItemSection.tsx
+++ b/apps/web/src/app/event/[category]/components/EventItemSection.tsx
@@ -6,7 +6,6 @@ import React, { Suspense } from 'react';
 import EventItems from './EventItems';
 import { useQueryErrorResetBoundary } from '@tanstack/react-query';
 import ApiErrorBoundary from '@/components/ApiErrorBoundary';
-import LoadingIndicator from '@/components/LoadingIndicator';
 
 interface EventItemSectionProps {
   category: Convenience;
@@ -33,7 +32,7 @@ const EventItemSection = ({ category }: EventItemSectionProps) => {
         </Chip>
       </div>
       <ApiErrorBoundary onReset={reset}>
-        <Suspense fallback={<LoadingIndicator />}>
+        <Suspense fallback={<EventItems.Skeleton />}>
           <EventItems category={category} />
         </Suspense>
       </ApiErrorBoundary>

--- a/apps/web/src/app/event/[category]/components/EventItemSection.tsx
+++ b/apps/web/src/app/event/[category]/components/EventItemSection.tsx
@@ -13,7 +13,7 @@ interface EventItemSectionProps {
 
 const EventItemSection = ({ category }: EventItemSectionProps) => {
   const { reset } = useQueryErrorResetBoundary();
-  const [eventType, setEventType] = useState<EventType>();
+  const [eventType, setEventType] = useState<EventType>('ONE_PLUS_ONE');
   return (
     <div className="px-[20px]">
       <div className="pb-[18px] pt-[40px]">

--- a/apps/web/src/app/event/[category]/components/EventItemSection.tsx
+++ b/apps/web/src/app/event/[category]/components/EventItemSection.tsx
@@ -1,8 +1,8 @@
 'use client';
-import { type Convenience } from '@/app/type';
+import { type EventType, type Convenience } from '@/app/type';
 import Chip from '@/components/Chip';
 import { EVENT_TYPE_LIST } from '@/constants/conveniences';
-import React, { Suspense } from 'react';
+import React, { Suspense, useState } from 'react';
 import EventItems from './EventItems';
 import { useQueryErrorResetBoundary } from '@tanstack/react-query';
 import ApiErrorBoundary from '@/components/ApiErrorBoundary';
@@ -13,6 +13,7 @@ interface EventItemSectionProps {
 
 const EventItemSection = ({ category }: EventItemSectionProps) => {
   const { reset } = useQueryErrorResetBoundary();
+  const [eventType, setEventType] = useState<EventType>();
   return (
     <div className="px-[20px]">
       <div className="pb-[18px] pt-[40px]">
@@ -24,16 +25,16 @@ const EventItemSection = ({ category }: EventItemSectionProps) => {
             <Chip.Item
               myIndex={index}
               key={index}
-              onClickChipItem={() => console.log('클릭!')}
+              onClickChipItem={() => setEventType(item.type)}
             >
-              {item}
+              {item.text}
             </Chip.Item>
           ))}
         </Chip>
       </div>
       <ApiErrorBoundary onReset={reset}>
         <Suspense fallback={<EventItems.Skeleton />}>
-          <EventItems category={category} />
+          <EventItems category={category} eventType={eventType} />
         </Suspense>
       </ApiErrorBoundary>
     </div>

--- a/apps/web/src/app/event/[category]/components/EventItems.tsx
+++ b/apps/web/src/app/event/[category]/components/EventItems.tsx
@@ -2,7 +2,7 @@
 import { PromotionGoodsCategory } from '@/apis/type';
 import { type Convenience } from '@/app/type';
 import EventItemCard from '@/components/EventItemCard';
-import { EVENT_TYPE_LIST, EventMapping } from '@/constants/conveniences';
+import { EventMapping } from '@/constants/conveniences';
 import { useGetPromotionGoods } from '@/hooks/query/usePromotion';
 import React from 'react';
 
@@ -30,6 +30,7 @@ const EventItems = ({ category }: EventItemsProps) => {
             imageUrl: promotion.goodsImageUrl,
             price: promotion.goodsPrice,
             title: promotion.goodsName,
+            goodsNo: promotion.goodsNo,
             convenience: mappingSegments[promotion.storeName],
           }}
         />
@@ -37,5 +38,17 @@ const EventItems = ({ category }: EventItemsProps) => {
     </div>
   );
 };
+
+const EventItemsSkeleton = () => {
+  return (
+    <div className="mb-[50px] flex flex-wrap items-start justify-start gap-x-[18px] gap-y-[50px]">
+      {Array.from({ length: 8 }, (_, i) => i).map((_, k) => (
+        <EventItemCard.Skeleton key={k} />
+      ))}
+    </div>
+  );
+};
+
+EventItems.Skeleton = EventItemsSkeleton;
 
 export default EventItems;

--- a/apps/web/src/app/event/[category]/components/EventItems.tsx
+++ b/apps/web/src/app/event/[category]/components/EventItems.tsx
@@ -1,0 +1,41 @@
+'use client';
+import { PromotionGoodsCategory } from '@/apis/type';
+import { type Convenience } from '@/app/type';
+import EventItemCard from '@/components/EventItemCard';
+import { EVENT_TYPE_LIST, EventMapping } from '@/constants/conveniences';
+import { useGetPromotionGoods } from '@/hooks/query/usePromotion';
+import React from 'react';
+
+interface EventItemsProps {
+  category: Convenience;
+}
+
+const mappingSegments: Record<PromotionGoodsCategory, Convenience> = {
+  ALL: 'ALL',
+  CU: 'CU',
+  GS25: 'GS25',
+  SEVEN11: '7Eleven',
+  EMART24: 'Emart24',
+} as const;
+
+const EventItems = ({ category }: EventItemsProps) => {
+  const { data } = useGetPromotionGoods({ type: EventMapping[category] });
+  return (
+    <div className="flex flex-wrap items-start justify-start gap-x-[18px] gap-y-[50px]">
+      {data?.map((promotion, idx) => (
+        <EventItemCard
+          key={`${idx}-${promotion.goodsNo}`}
+          eventItem={{
+            eventType: promotion.promotionType,
+            imageUrl: promotion.goodsImageUrl,
+            price: promotion.goodsPrice,
+            title: promotion.goodsName,
+            convenience: mappingSegments[promotion.storeName],
+          }}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default EventItems;

--- a/apps/web/src/app/event/[category]/components/EventItems.tsx
+++ b/apps/web/src/app/event/[category]/components/EventItems.tsx
@@ -3,7 +3,7 @@ import { PromotionGoodsCategory } from '@/apis/type';
 import { EventType, type Convenience } from '@/app/type';
 import EventItemCard from '@/components/EventItemCard';
 import { EventMapping } from '@/constants/conveniences';
-import { useGetPromotionGoods } from '@/hooks/query/usePromotion';
+import { useGetPromotionGoodsList } from '@/hooks/query/usePromotion';
 import React from 'react';
 
 interface EventItemsProps {
@@ -20,25 +20,27 @@ const mappingSegments: Record<PromotionGoodsCategory, Convenience> = {
 } as const;
 
 const EventItems = ({ category, eventType }: EventItemsProps) => {
-  const { data } = useGetPromotionGoods({
+  const { data, fetchNextPage, isFetchingNextPage } = useGetPromotionGoodsList({
     type: EventMapping[category],
     promotionType: eventType,
   });
   return (
     <div className="flex flex-wrap items-start justify-start gap-x-[18px] gap-y-[50px]">
-      {data?.map((promotion, idx) => (
-        <EventItemCard
-          key={`${idx}-${promotion.goodsNo}`}
-          eventItem={{
-            eventType: promotion.promotionType,
-            imageUrl: promotion.goodsImageUrl,
-            price: promotion.goodsPrice,
-            title: promotion.goodsName,
-            goodsNo: promotion.goodsNo,
-            convenience: mappingSegments[promotion.storeName],
-          }}
-        />
-      ))}
+      {data?.pages.map((page) =>
+        page.data.map((promotion, idx) => (
+          <EventItemCard
+            key={`${idx}-${promotion.goodsNo}`}
+            eventItem={{
+              eventType: promotion.promotionType,
+              imageUrl: promotion.goodsImageUrl,
+              price: promotion.goodsPrice,
+              title: promotion.goodsName,
+              goodsNo: promotion.goodsNo,
+              convenience: mappingSegments[promotion.storeName],
+            }}
+          />
+        )),
+      )}
     </div>
   );
 };

--- a/apps/web/src/app/event/[category]/components/EventItems.tsx
+++ b/apps/web/src/app/event/[category]/components/EventItems.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { PromotionGoodsCategory } from '@/apis/type';
-import { type Convenience } from '@/app/type';
+import { EventType, type Convenience } from '@/app/type';
 import EventItemCard from '@/components/EventItemCard';
 import { EventMapping } from '@/constants/conveniences';
 import { useGetPromotionGoods } from '@/hooks/query/usePromotion';
@@ -8,6 +8,7 @@ import React from 'react';
 
 interface EventItemsProps {
   category: Convenience;
+  eventType: EventType;
 }
 
 const mappingSegments: Record<PromotionGoodsCategory, Convenience> = {
@@ -18,8 +19,11 @@ const mappingSegments: Record<PromotionGoodsCategory, Convenience> = {
   EMART24: 'Emart24',
 } as const;
 
-const EventItems = ({ category }: EventItemsProps) => {
-  const { data } = useGetPromotionGoods({ type: EventMapping[category] });
+const EventItems = ({ category, eventType }: EventItemsProps) => {
+  const { data } = useGetPromotionGoods({
+    type: EventMapping[category],
+    promotionType: eventType,
+  });
   return (
     <div className="flex flex-wrap items-start justify-start gap-x-[18px] gap-y-[50px]">
       {data?.map((promotion, idx) => (

--- a/apps/web/src/app/event/[category]/components/EventItems.tsx
+++ b/apps/web/src/app/event/[category]/components/EventItems.tsx
@@ -4,7 +4,8 @@ import { EventType, type Convenience } from '@/app/type';
 import EventItemCard from '@/components/EventItemCard';
 import { EventMapping } from '@/constants/conveniences';
 import { useGetPromotionGoodsList } from '@/hooks/query/usePromotion';
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useInView } from 'react-intersection-observer';
 
 interface EventItemsProps {
   category: Convenience;
@@ -24,24 +25,35 @@ const EventItems = ({ category, eventType }: EventItemsProps) => {
     type: EventMapping[category],
     promotionType: eventType,
   });
+  const { ref, inView } = useInView();
+
+  useEffect(() => {
+    if (inView && data?.pages) {
+      fetchNextPage();
+    }
+  }, [inView]);
+
   return (
-    <div className="flex flex-wrap items-start justify-start gap-x-[18px] gap-y-[50px]">
-      {data?.pages.map((page) =>
-        page.data.map((promotion, idx) => (
-          <EventItemCard
-            key={`${idx}-${promotion.goodsNo}`}
-            eventItem={{
-              eventType: promotion.promotionType,
-              imageUrl: promotion.goodsImageUrl,
-              price: promotion.goodsPrice,
-              title: promotion.goodsName,
-              goodsNo: promotion.goodsNo,
-              convenience: mappingSegments[promotion.storeName],
-            }}
-          />
-        )),
-      )}
-    </div>
+    <>
+      <div className="flex flex-wrap items-start justify-start gap-x-[18px] gap-y-[50px]">
+        {data?.pages.map((page) =>
+          page.data.map((promotion, idx) => (
+            <EventItemCard
+              key={`${idx}-${promotion.goodsNo}`}
+              eventItem={{
+                eventType: promotion.promotionType,
+                imageUrl: promotion.goodsImageUrl,
+                price: promotion.goodsPrice,
+                title: promotion.goodsName,
+                goodsNo: promotion.goodsNo,
+                convenience: mappingSegments[promotion.storeName],
+              }}
+            />
+          )),
+        )}
+      </div>
+      {isFetchingNextPage ? <div>Loading...</div> : <div ref={ref} />}
+    </>
   );
 };
 

--- a/apps/web/src/app/event/[category]/detail/[id]/components/EventItemTotalSection.tsx
+++ b/apps/web/src/app/event/[category]/detail/[id]/components/EventItemTotalSection.tsx
@@ -15,7 +15,7 @@ const EventItemTotalSection = () => {
         </Link>
       </div>
       <div className="flex flex-wrap items-start justify-start gap-x-[18px] gap-y-[50px]">
-        {Array.from({ length: 8 }).map((_, i) => (
+        {/* {Array.from({ length: 8 }).map((_, i) => (
           <EventItemCard
             key={i}
             eventItem={{
@@ -26,7 +26,7 @@ const EventItemTotalSection = () => {
               convenience: '7Eleven',
             }}
           />
-        ))}
+        ))} */}
       </div>
     </div>
   );

--- a/apps/web/src/app/event/[category]/detail/[id]/page.tsx
+++ b/apps/web/src/app/event/[category]/detail/[id]/page.tsx
@@ -23,35 +23,17 @@ const EventItemDetailPage = ({
   params: { category, id },
 }: EventItemDetailPageProps) => {
   return (
-    <BasicLayout
-      hasBackButton
-      headerCenter={'이번주 행사 상품'}
-      headerRight={
-        <div className="flex items-center">
-          <HomeIconButton />
-          <SearchIconButton type="white" />
-        </div>
-      }
-    >
-      <div>
-        <div className="sticky top-[58px] z-40">
-          <TabCategory
-            categoryData={categoryInfoList}
-            currentCategory={category}
-            isRouterReplace={true}
-          />
-        </div>
-        <div className="border-b border-[#D7D7D7] bg-white">
-          <EventItemDetailSection />
-        </div>
-        <div className="mt-[15px] bg-white">
-          <EventItemTotalSection />
-        </div>
-        <div className="fixed bottom-7 right-6 z-50 ml-auto mr-auto">
-          <TopButton />
-        </div>
+    <div>
+      <div className="border-b border-[#D7D7D7] bg-white">
+        <EventItemDetailSection />
       </div>
-    </BasicLayout>
+      <div className="mt-[15px] bg-white">
+        <EventItemTotalSection />
+      </div>
+      <div className="fixed bottom-7 right-6 z-50 ml-auto mr-auto">
+        <TopButton />
+      </div>
+    </div>
   );
 };
 

--- a/apps/web/src/app/event/[category]/layout.tsx
+++ b/apps/web/src/app/event/[category]/layout.tsx
@@ -1,0 +1,53 @@
+import { Convenience } from '@/app/type';
+import BasicLayout from '@/components/BasicLayout';
+import TabCategory from '@/components/TabCategory';
+import TopButton from '@/components/TopButton';
+import React from 'react';
+import HomeIconButton from '@/components/HomeIconButton';
+import SearchIconButton from '@/components/SearchIconButton';
+import { CONVENIENCE } from '@/constants/conveniences';
+
+const categoryInfoList = CONVENIENCE.map((convenience) => ({
+  category: convenience,
+  label: convenience,
+  href: `/event/${convenience}`,
+}));
+
+interface EventCategoryPageProps {
+  params: { category: Convenience };
+  children: React.ReactNode;
+}
+
+const EventCategoryPageLayout = ({
+  params: { category },
+  children,
+}: EventCategoryPageProps) => {
+  return (
+    <BasicLayout
+      hasBackButton
+      headerCenter={'이번주 행사 상품'}
+      headerRight={
+        <div className="flex items-center">
+          <HomeIconButton />
+          <SearchIconButton type="white" />
+        </div>
+      }
+    >
+      <div className="bg-white pb-[75px]">
+        <div className="sticky top-[58px] z-40">
+          <TabCategory
+            categoryData={categoryInfoList}
+            currentCategory={category}
+            isRouterReplace={true}
+          />
+        </div>
+        {children}
+        <div className="fixed bottom-7 right-6 z-50 ml-auto mr-auto">
+          <TopButton />
+        </div>
+      </div>
+    </BasicLayout>
+  );
+};
+
+export default EventCategoryPageLayout;

--- a/apps/web/src/app/event/[category]/page.tsx
+++ b/apps/web/src/app/event/[category]/page.tsx
@@ -1,18 +1,6 @@
 import { Convenience } from '@/app/type';
-import BasicLayout from '@/components/BasicLayout';
-import TabCategory from '@/components/TabCategory';
-import TopButton from '@/components/TopButton';
 import React from 'react';
 import EventItemSection from './components/EventItemSection';
-import HomeIconButton from '@/components/HomeIconButton';
-import SearchIconButton from '@/components/SearchIconButton';
-import { CONVENIENCE } from '@/constants/conveniences';
-
-const categoryInfoList = CONVENIENCE.map((convenience) => ({
-  category: convenience,
-  label: convenience,
-  href: `/event/${convenience}`,
-}));
 
 interface EventCategoryPageProps {
   params: { category: Convenience };
@@ -21,32 +9,7 @@ interface EventCategoryPageProps {
 const EventCategoryPage = ({
   params: { category },
 }: EventCategoryPageProps) => {
-  return (
-    <BasicLayout
-      hasBackButton
-      headerCenter={'이번주 행사 상품'}
-      headerRight={
-        <div className="flex items-center">
-          <HomeIconButton />
-          <SearchIconButton type="white" />
-        </div>
-      }
-    >
-      <div className="bg-white pb-[75px]">
-        <div className="sticky top-[58px] z-40">
-          <TabCategory
-            categoryData={categoryInfoList}
-            currentCategory={category}
-            isRouterReplace={true}
-          />
-        </div>
-        <EventItemSection />
-        <div className="fixed bottom-7 right-6 z-50 ml-auto mr-auto">
-          <TopButton />
-        </div>
-      </div>
-    </BasicLayout>
-  );
+  return <EventItemSection category={category} />;
 };
 
 export default EventCategoryPage;

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -30,7 +30,6 @@ export default function RootLayout({
                 alt="intro-contents"
                 width={345}
                 height={190}
-                priority
               />
             </div>
             {/* spacing block */}
@@ -41,7 +40,6 @@ export default function RootLayout({
                 alt="handpyeon-text"
                 width={300}
                 height={113}
-                priority
               />
               <div className="absolute right-[_-80px] top-[_-65px] h-[84px] w-[84px]">
                 <Image
@@ -49,7 +47,6 @@ export default function RootLayout({
                   alt="left-arrow"
                   width={68}
                   height={68}
-                  priority
                 />
               </div>
               <div className="absolute bottom-[_-130px] left-[_-80px] h-[84px] w-[84px]">
@@ -58,7 +55,6 @@ export default function RootLayout({
                   alt="right-arrow"
                   width={68}
                   height={68}
-                  priority
                 />
               </div>
             </div>
@@ -70,7 +66,6 @@ export default function RootLayout({
             alt="brand-contents"
             width={746}
             height={226}
-            priority
           />
         </div>
         <main className="flex min-h-full w-full justify-center lg:justify-normal">

--- a/apps/web/src/app/main/[category]/EventItems.tsx
+++ b/apps/web/src/app/main/[category]/EventItems.tsx
@@ -4,7 +4,7 @@ import { Convenience } from '@/app/type';
 import EventItemCard from '@/components/EventItemCard';
 import ChevronIcon from '@/components/icons/ChevronIcon';
 import { EventMapping } from '@/constants/conveniences';
-import { useGetPromotionGoods } from '@/hooks/query/usePromotion';
+import { useGetPromotionGoodsList } from '@/hooks/query/usePromotion';
 import { useRouter } from 'next/navigation';
 
 interface EventItemsProps {
@@ -21,7 +21,9 @@ const mappingSegments: Record<PromotionGoodsCategory, Convenience> = {
 
 function EventItems({ convenience }: EventItemsProps) {
   const router = useRouter();
-  const { data } = useGetPromotionGoods({ type: EventMapping[convenience] });
+  const { data } = useGetPromotionGoodsList({
+    type: EventMapping[convenience],
+  });
   const goEventPage = () => {
     router.push(`/event/${convenience}`);
   };

--- a/apps/web/src/app/main/[category]/EventItems.tsx
+++ b/apps/web/src/app/main/[category]/EventItems.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { HotTrendCategory } from '@/apis/type';
+import { PromotionGoodsCategory } from '@/apis/type';
 import { Convenience } from '@/app/type';
 import EventItemCard from '@/components/EventItemCard';
 import ChevronIcon from '@/components/icons/ChevronIcon';
@@ -11,7 +11,7 @@ interface EventItemsProps {
   convenience: Convenience;
 }
 
-const mappingSegments: Record<HotTrendCategory, Convenience> = {
+const mappingSegments: Record<PromotionGoodsCategory, Convenience> = {
   ALL: 'ALL',
   CU: 'CU',
   GS25: 'GS25',

--- a/apps/web/src/app/main/[category]/EventItems.tsx
+++ b/apps/web/src/app/main/[category]/EventItems.tsx
@@ -4,7 +4,7 @@ import { Convenience } from '@/app/type';
 import EventItemCard from '@/components/EventItemCard';
 import ChevronIcon from '@/components/icons/ChevronIcon';
 import { EventMapping } from '@/constants/conveniences';
-import { useGetPromotionGoodsList } from '@/hooks/query/usePromotion';
+import { useGetFirstPagePromotionGoodsList } from '@/hooks/query/usePromotion';
 import { useRouter } from 'next/navigation';
 
 interface EventItemsProps {
@@ -21,7 +21,7 @@ const mappingSegments: Record<PromotionGoodsCategory, Convenience> = {
 
 function EventItems({ convenience }: EventItemsProps) {
   const router = useRouter();
-  const { data } = useGetPromotionGoodsList({
+  const { data } = useGetFirstPagePromotionGoodsList({
     type: EventMapping[convenience],
   });
   const goEventPage = () => {
@@ -30,7 +30,7 @@ function EventItems({ convenience }: EventItemsProps) {
   return (
     <div>
       <div className="mb-[50px] flex flex-wrap items-start justify-start gap-x-[18px] gap-y-[50px]">
-        {data?.map((promotion, idx) => (
+        {data?.data.map((promotion, idx) => (
           <EventItemCard
             key={`${idx}-${promotion.goodsNo}`}
             eventItem={{

--- a/apps/web/src/app/main/[category]/EventItems.tsx
+++ b/apps/web/src/app/main/[category]/EventItems.tsx
@@ -19,7 +19,7 @@ const mappingSegments: Record<HotTrendCategory, Convenience> = {
   EMART24: 'Emart24',
 } as const;
 
-export default function EventItems({ convenience }: EventItemsProps) {
+function EventItems({ convenience }: EventItemsProps) {
   const router = useRouter();
   const { data } = useGetPromotionGoods(EventMapping[convenience]);
   const goEventPage = () => {
@@ -53,3 +53,25 @@ export default function EventItems({ convenience }: EventItemsProps) {
     </div>
   );
 }
+
+const EventItemsSkeleton = () => {
+  return (
+    <div className="mb-[50px] flex flex-wrap items-start justify-start gap-x-[18px] gap-y-[50px]">
+      {Array.from({ length: 8 }, (_, i) => i).map((_, k) => (
+        <div className="w-[calc(50%_-_9px)] animate-pulse" key={k}>
+          <div className="aspect-square w-full rounded bg-slate-200" />
+          <hr className="h-[10px]" />
+          <div className="flex flex-col gap-1">
+            <div className="h-[9px] w-[35px] rounded bg-slate-200"></div>
+            <div className="h-[12px] w-full rounded bg-slate-200"></div>
+            <div className="h-[12px] w-1/2 rounded bg-slate-200"></div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+EventItems.Skeleton = EventItemsSkeleton;
+
+export default EventItems;

--- a/apps/web/src/app/main/[category]/EventItems.tsx
+++ b/apps/web/src/app/main/[category]/EventItems.tsx
@@ -36,6 +36,7 @@ function EventItems({ convenience }: EventItemsProps) {
               imageUrl: promotion.goodsImageUrl,
               price: promotion.goodsPrice,
               title: promotion.goodsName,
+              goodsNo: promotion.goodsNo,
               convenience: mappingSegments[promotion.storeName],
             }}
           />
@@ -58,15 +59,7 @@ const EventItemsSkeleton = () => {
   return (
     <div className="mb-[50px] flex flex-wrap items-start justify-start gap-x-[18px] gap-y-[50px]">
       {Array.from({ length: 8 }, (_, i) => i).map((_, k) => (
-        <div className="w-[calc(50%_-_9px)] animate-pulse" key={k}>
-          <div className="aspect-square w-full rounded bg-slate-200" />
-          <hr className="h-[10px]" />
-          <div className="flex flex-col gap-1">
-            <div className="h-[9px] w-[35px] rounded bg-slate-200"></div>
-            <div className="h-[12px] w-full rounded bg-slate-200"></div>
-            <div className="h-[12px] w-1/2 rounded bg-slate-200"></div>
-          </div>
-        </div>
+        <EventItemCard.Skeleton key={k} />
       ))}
     </div>
   );

--- a/apps/web/src/app/main/[category]/EventItems.tsx
+++ b/apps/web/src/app/main/[category]/EventItems.tsx
@@ -21,7 +21,7 @@ const mappingSegments: Record<HotTrendCategory, Convenience> = {
 
 function EventItems({ convenience }: EventItemsProps) {
   const router = useRouter();
-  const { data } = useGetPromotionGoods(EventMapping[convenience]);
+  const { data } = useGetPromotionGoods({ type: EventMapping[convenience] });
   const goEventPage = () => {
     router.push(`/event/${convenience}`);
   };

--- a/apps/web/src/app/main/[category]/page.tsx
+++ b/apps/web/src/app/main/[category]/page.tsx
@@ -42,7 +42,7 @@ export default function CategoryPage({
           </Suspense>
         </ApiErrorBoundary>
         <ApiErrorBoundary onReset={reset}>
-          <Suspense fallback={<Loading />}>
+          <Suspense fallback={<EventItems.Skeleton />}>
             <EventItems convenience={category} />
           </Suspense>
         </ApiErrorBoundary>

--- a/apps/web/src/app/search/view/SearchResultView.tsx
+++ b/apps/web/src/app/search/view/SearchResultView.tsx
@@ -29,7 +29,7 @@ const SearchResultView = () => {
           <span>292개의 검색결과</span>
         </div>
         <div className="flex flex-wrap items-start justify-start gap-x-[18px] gap-y-[50px]">
-          {Array.from({ length: 8 }).map((_, i) => (
+          {/* {Array.from({ length: 8 }).map((_, i) => (
             <EventItemCard
               key={i}
               eventItem={{
@@ -40,7 +40,7 @@ const SearchResultView = () => {
                 convenience: '7Eleven',
               }}
             />
-          ))}
+          ))} */}
         </div>
       </div>
     </div>

--- a/apps/web/src/components/EventItemCard/index.tsx
+++ b/apps/web/src/components/EventItemCard/index.tsx
@@ -6,6 +6,7 @@ import { EVENT_TYPE_MAP } from '@/constants/conveniences';
 import Link from 'next/link';
 import { type PromotionType } from '@/apis/type';
 interface EventItem {
+  goodsNo: number;
   eventType: PromotionType;
   imageUrl: string;
   price: number;
@@ -18,11 +19,11 @@ interface Props {
 }
 
 const EventItemCard = ({
-  eventItem: { eventType, imageUrl, convenience, title, price },
+  eventItem: { eventType, imageUrl, convenience, title, price, goodsNo },
 }: Props) => {
   return (
     <div className="w-[calc(50%_-_9px)]">
-      <Link href={`/event/${convenience}/detail/1`}>
+      <Link href={`/event/${convenience}/detail/${goodsNo}`}>
         <div className="mb-[12px] aspect-square w-full rounded-[9px] border-2 border-b-[4px] border-r-[4px] border-black p-[5px]">
           <div className="relative flex h-full w-full items-center justify-center">
             <div
@@ -61,5 +62,21 @@ const EventItemCard = ({
     </div>
   );
 };
+
+const EventItemCardSekelton = () => {
+  return (
+    <div className="w-[calc(50%_-_9px)] animate-pulse">
+      <div className="aspect-square w-full rounded bg-slate-200" />
+      <hr className="h-[10px]" />
+      <div className="flex flex-col gap-1">
+        <div className="h-[9px] w-[35px] rounded bg-slate-200"></div>
+        <div className="h-[12px] w-full rounded bg-slate-200"></div>
+        <div className="h-[12px] w-1/2 rounded bg-slate-200"></div>
+      </div>
+    </div>
+  );
+};
+
+EventItemCard.Skeleton = EventItemCardSekelton;
 
 export default EventItemCard;

--- a/apps/web/src/constants/conveniences.ts
+++ b/apps/web/src/constants/conveniences.ts
@@ -19,7 +19,12 @@ export const HotTrendMapping: Record<Convenience, HotTrendCategory> = {
   Emart24: 'EMART24',
 } as const;
 
-export const EVENT_TYPE_LIST = ['1+1', '2+1', '할인', '+덤'];
+export const EVENT_TYPE_LIST: { text: string; type: EventType }[] = [
+  { text: '1+1', type: 'ONE_PLUS_ONE' },
+  { text: '2+1', type: 'TWO_PLUS_ONE' },
+  { text: '할인', type: 'SALE' },
+  { text: '+덤', type: 'BONUS' },
+];
 
 export const EVENT_TYPE_MAP: Record<EventType, { text: string; bg: string }> = {
   ONE_PLUS_ONE: { text: '1+1', bg: 'bg-[#73F69D]' },

--- a/apps/web/src/hooks/query/usePromotion.ts
+++ b/apps/web/src/hooks/query/usePromotion.ts
@@ -37,3 +37,19 @@ export const useGetPromotionGoodsList = ({
     useErrorBoundary: true,
   });
 };
+
+export const useGetFirstPagePromotionGoodsList = ({
+  type,
+}: PromotionGoodsParams) => {
+  return useQuery({
+    queryKey: promotionQueryKey.list({
+      type,
+    }),
+    queryFn: () =>
+      getPromotionGoodsList({
+        type,
+      }),
+    suspense: true,
+    useErrorBoundary: true,
+  });
+};

--- a/apps/web/src/hooks/query/usePromotion.ts
+++ b/apps/web/src/hooks/query/usePromotion.ts
@@ -13,12 +13,13 @@ export const promotionQueryKey = {
 
 export const useGetPromotionGoods = ({
   type,
+  promotionType,
   keyword,
   cursor,
 }: PromotionGoodsParams) => {
   return useQuery({
-    queryKey: promotionQueryKey.list({ type, keyword, cursor }),
-    queryFn: () => getPromotionGoods({ type, keyword, cursor }),
+    queryKey: promotionQueryKey.list({ type, promotionType, keyword, cursor }),
+    queryFn: () => getPromotionGoods({ type, promotionType, keyword, cursor }),
     suspense: true,
     useErrorBoundary: true,
   });

--- a/apps/web/src/hooks/query/usePromotion.ts
+++ b/apps/web/src/hooks/query/usePromotion.ts
@@ -30,7 +30,7 @@ export const useGetPromotionGoodsList = ({
         cursor: pageParam,
       }),
     getNextPageParam: (lastPage) =>
-      lastPage.pageInfo.totalPages !== lastPage.currentPage
+      lastPage.pageInfo.totalPages !== lastPage.nextCursor
         ? lastPage.nextCursor
         : undefined,
     suspense: true,

--- a/apps/web/src/hooks/query/usePromotion.ts
+++ b/apps/web/src/hooks/query/usePromotion.ts
@@ -1,5 +1,8 @@
-import { useQuery } from '@tanstack/react-query';
-import { type PromotionGoodsParams, getPromotionGoods } from '@/apis/promotion';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import {
+  type PromotionGoodsParams,
+  getPromotionGoodsList,
+} from '@/apis/promotion';
 
 export const promotionQueryKey = {
   all: ['promotion'] as const,
@@ -11,15 +14,25 @@ export const promotionQueryKey = {
     [...promotionQueryKey.details(), goodsNo] as const,
 };
 
-export const useGetPromotionGoods = ({
+export const useGetPromotionGoodsList = ({
   type,
   promotionType,
   keyword,
   cursor,
 }: PromotionGoodsParams) => {
-  return useQuery({
+  return useInfiniteQuery({
     queryKey: promotionQueryKey.list({ type, promotionType, keyword, cursor }),
-    queryFn: () => getPromotionGoods({ type, promotionType, keyword, cursor }),
+    queryFn: ({ pageParam = 0 }) =>
+      getPromotionGoodsList({
+        type,
+        promotionType,
+        keyword,
+        cursor: pageParam,
+      }),
+    getNextPageParam: (lastPage) =>
+      lastPage.pageInfo.totalPages !== lastPage.currentPage
+        ? lastPage.nextCursor
+        : undefined,
     suspense: true,
     useErrorBoundary: true,
   });

--- a/apps/web/src/hooks/query/usePromotion.ts
+++ b/apps/web/src/hooks/query/usePromotion.ts
@@ -1,6 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { getPromotionGoods } from '@/apis/promotion';
-import { PromotionGoodsParams } from '@/apis/promotion';
+import { type PromotionGoodsParams, getPromotionGoods } from '@/apis/promotion';
 
 export const promotionQueryKey = {
   all: ['promotion'] as const,
@@ -12,10 +11,14 @@ export const promotionQueryKey = {
     [...promotionQueryKey.details(), goodsNo] as const,
 };
 
-export const useGetPromotionGoods = (params: PromotionGoodsParams) => {
+export const useGetPromotionGoods = ({
+  type,
+  keyword,
+  cursor,
+}: PromotionGoodsParams) => {
   return useQuery({
-    queryKey: promotionQueryKey.list(params),
-    queryFn: () => getPromotionGoods(params),
+    queryKey: promotionQueryKey.list({ type, keyword, cursor }),
+    queryFn: () => getPromotionGoods({ type, keyword, cursor }),
     suspense: true,
     useErrorBoundary: true,
   });

--- a/apps/web/src/hooks/query/usePromotion.ts
+++ b/apps/web/src/hooks/query/usePromotion.ts
@@ -16,6 +16,7 @@ export const useGetPromotionGoods = (params: PromotionGoodsParams) => {
   return useQuery({
     queryKey: promotionQueryKey.list(params),
     queryFn: () => getPromotionGoods(params),
+    suspense: true,
     useErrorBoundary: true,
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8548,6 +8548,11 @@ react-inspector@^6.0.0:
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-6.0.1.tgz#1a37f0165d9df81ee804d63259eaaeabe841287d"
   integrity sha512-cxKSeFTf7jpSSVddm66sKdolG90qURAX3g1roTeaN6x0YEbtWc8JpmFN9+yIqLNH2uEkYerWLtJZIXRIFuBKrg==
 
+react-intersection-observer@^9.5.2:
+  version "9.5.2"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-9.5.2.tgz#f68363a1ff292323c0808201b58134307a1626d0"
+  integrity sha512-EmoV66/yvksJcGa1rdW0nDNc4I1RifDWkT50gXSFnPLYQ4xUptuDD4V7k+Rj1OgVAlww628KLGcxPXFlOkkU/Q==
+
 react-is@18.1.0:
   version "18.1.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.1.0.tgz#61aaed3096d30eacf2a2127118b5b41387d32a67"


### PR DESCRIPTION
## 한 줄 요약
- 행사상품 리스트 api 연결 `/handpyeon/api/promotionGoods`

## 자세한 내용
- EventItemCard 컴포넌트에 Skeleton ui 추가
- EventItemCard 컴포넌트에 `goodsNo` props 추가
- event/[category] 쪽 페이지에 `layout` 파일 생성
- infinite scroll 적용
- 단일 페이지 조회를 위한 `useGetFirstPagePromotionGoodsList` 쿼리 함수 생성
- `getPromotionGoodsList` api의 응답에 `nextCursor` 추가 