### PR TITLE
feat(web): 추천 콘텐츠 배너 API 업데이트 

### DIFF
--- a/apps/web/src/apis/recommendation.ts
+++ b/apps/web/src/apis/recommendation.ts
@@ -2,18 +2,33 @@ import { RecommendationCategory } from '@/app/type';
 import httpClient from '@/http/client';
 
 import {
+  PageInfo,
   RecommendationBanner,
   RecommendationDetail,
   RecommendationSummary,
 } from './type';
 
+const TRESH_TEXTS = ['http://~', 'https://~', '://~'];
+const DEFAULT_BANNER_IMAGE = '/image/banner1.png';
+
+function checkTreshURL(url: string) {
+  if (TRESH_TEXTS.some((text) => url.includes(text)))
+    return DEFAULT_BANNER_IMAGE;
+  return url;
+}
+
+interface RecommendationBannersResponse {
+  pageInfo: PageInfo | null;
+  data: RecommendationBanner[];
+}
+
 export const getRecommendationBanners = async () => {
-  const { data } = await httpClient.get<{ data: RecommendationBanner[] }>(
+  const { data } = await httpClient.get<RecommendationBannersResponse>(
     '/handpyeon/api/banners/recommend',
   );
 
-  return data.data.map(({ bannerImage, contentsNumber }) => ({
-    src: bannerImage,
+  return data.data.map(({ bannerImageUrl, contentsNumber }) => ({
+    src: checkTreshURL(bannerImageUrl),
     url: `/recommendation/contents/${contentsNumber}`,
   }));
 };

--- a/apps/web/src/apis/type.ts
+++ b/apps/web/src/apis/type.ts
@@ -29,7 +29,8 @@ export interface HotTrendGoods {
 }
 
 export interface RecommendationBanner {
-  bannerImage: string;
+  id: number;
+  bannerImageUrl: string;
   contentsNumber: number;
 }
 
@@ -52,4 +53,9 @@ export interface RecommendationDetail {
   recommendStartDate: string;
   recommendEndDate: string;
   contentsList: RecommendationDetailContent[];
+}
+
+export interface PageInfo {
+  totalElements: number;
+  totalPages: number;
 }


### PR DESCRIPTION
## 한 줄 요약
추천 콘텐츠 배너 API 업데이트 

## 자세한 내용
- 추천 콘텐츠 배너 API 응답데이터 인터페이스가 변경되어 반영처리 
- "http://~" 와 같은 더미데이터를 받으면 next/image 에서 에러를 내기 때문에 데이터 확인 로직 추가 
