### PR TITLE
feat(web): 행사상품 디테일 페이지 api 연동

### DIFF
--- a/apps/web/src/apis/promotion.ts
+++ b/apps/web/src/apis/promotion.ts
@@ -12,6 +12,13 @@ export interface PromotionGoodsParams {
   cursor?: number;
 }
 
+export const getPromotionGoods = async (goodsNo: number) => {
+  const { data } = await httpClient.get<{ data: PromotionGoods }>(
+    `/handpyeon/api/promotionGoods/${goodsNo}`,
+  );
+  return data.data;
+};
+
 export const getPromotionGoodsList = async (params: PromotionGoodsParams) => {
   const {
     data: { data, pageInfo },

--- a/apps/web/src/apis/promotion.ts
+++ b/apps/web/src/apis/promotion.ts
@@ -1,5 +1,6 @@
 import httpClient from '@/http/client';
 import type {
+  PromotionGoods,
   PromotionGoodsCategory,
   PromotionGoodsList,
   PromotionType,

--- a/apps/web/src/app/event/[category]/detail/[id]/components/EventItemDetailSection.tsx
+++ b/apps/web/src/app/event/[category]/detail/[id]/components/EventItemDetailSection.tsx
@@ -2,11 +2,10 @@
 import React from 'react';
 import EventItemDetailCard from './EventItemDetailCard';
 import BannerSlides from '@/components/BannerSlides';
-import { BANNER_DATA } from '@/constants/assets';
 import { useGetPromotionGoods } from '@/hooks/query/usePromotion';
 import type { PromotionGoodsCategory } from '@/apis/type';
 import type { Convenience } from '@/app/type';
-import { useGetRecommendationContents } from '@/hooks/query/useRecommendation';
+import { useGetRecommendationBanners } from '@/hooks/query/useRecommendation';
 
 interface EventItemDetailSectionProps {
   goodsNo: number;
@@ -22,7 +21,7 @@ const mappingSegments: Record<PromotionGoodsCategory, Convenience> = {
 
 const EventItemDetailSection = ({ goodsNo }: EventItemDetailSectionProps) => {
   const { data } = useGetPromotionGoods(goodsNo);
-  const { data: bannerData } = useGetRecommendationContents();
+  const { data: bannerData } = useGetRecommendationBanners();
   return (
     <div className="px-[20px]">
       <div className="pb-[20px] pt-[29px]">

--- a/apps/web/src/app/event/[category]/detail/[id]/components/EventItemDetailSection.tsx
+++ b/apps/web/src/app/event/[category]/detail/[id]/components/EventItemDetailSection.tsx
@@ -6,6 +6,7 @@ import { BANNER_DATA } from '@/constants/assets';
 import { useGetPromotionGoods } from '@/hooks/query/usePromotion';
 import type { PromotionGoodsCategory } from '@/apis/type';
 import type { Convenience } from '@/app/type';
+import { useGetRecommendationContents } from '@/hooks/query/useRecommendation';
 
 interface EventItemDetailSectionProps {
   goodsNo: number;
@@ -21,6 +22,7 @@ const mappingSegments: Record<PromotionGoodsCategory, Convenience> = {
 
 const EventItemDetailSection = ({ goodsNo }: EventItemDetailSectionProps) => {
   const { data } = useGetPromotionGoods(goodsNo);
+  const { data: bannerData } = useGetRecommendationContents();
   return (
     <div className="px-[20px]">
       <div className="pb-[20px] pt-[29px]">
@@ -37,7 +39,7 @@ const EventItemDetailSection = ({ goodsNo }: EventItemDetailSectionProps) => {
       </div>
       <div className=" pb-[30px]">
         <div className="h-[178px] overflow-hidden rounded-[10px]">
-          <BannerSlides data={BANNER_DATA} totalViewURL="/recommendation" />
+          <BannerSlides data={bannerData} totalViewURL="/recommendation" />
         </div>
       </div>
     </div>

--- a/apps/web/src/app/event/[category]/detail/[id]/components/EventItemDetailSection.tsx
+++ b/apps/web/src/app/event/[category]/detail/[id]/components/EventItemDetailSection.tsx
@@ -1,10 +1,26 @@
+'use client';
 import React from 'react';
 import EventItemDetailCard from './EventItemDetailCard';
 import BannerSlides from '@/components/BannerSlides';
-import { pyeonImage } from '@/dummy/image';
 import { BANNER_DATA } from '@/constants/assets';
+import { useGetPromotionGoods } from '@/hooks/query/usePromotion';
+import type { PromotionGoodsCategory } from '@/apis/type';
+import type { Convenience } from '@/app/type';
 
-const EventItemDetailSection = () => {
+interface EventItemDetailSectionProps {
+  goodsNo: number;
+}
+
+const mappingSegments: Record<PromotionGoodsCategory, Convenience> = {
+  ALL: 'ALL',
+  CU: 'CU',
+  GS25: 'GS25',
+  SEVEN11: '7Eleven',
+  EMART24: 'Emart24',
+} as const;
+
+const EventItemDetailSection = ({ goodsNo }: EventItemDetailSectionProps) => {
+  const { data } = useGetPromotionGoods(goodsNo);
   return (
     <div className="px-[20px]">
       <div className="pb-[20px] pt-[29px]">
@@ -12,11 +28,11 @@ const EventItemDetailSection = () => {
       </div>
       <div className="pb-[37px]">
         <EventItemDetailCard
-          category="Emart24"
-          eventType="BONUS"
-          imageUrl={pyeonImage}
-          productName="스프라이트P500ml"
-          price={2000}
+          category={mappingSegments[data.storeName]}
+          eventType={data.promotionType}
+          imageUrl={data.goodsImageUrl}
+          productName={data.goodsName}
+          price={data.goodsPrice}
         />
       </div>
       <div className=" pb-[30px]">

--- a/apps/web/src/app/event/[category]/detail/[id]/components/EventItemTotalSection.tsx
+++ b/apps/web/src/app/event/[category]/detail/[id]/components/EventItemTotalSection.tsx
@@ -1,9 +1,28 @@
+'use client';
+import { PromotionGoodsCategory } from '@/apis/type';
+import { Convenience } from '@/app/type';
 import EventItemCard from '@/components/EventItemCard';
-import { pyeonImage } from '@/dummy/image';
+import { EventMapping } from '@/constants/conveniences';
+import { useGetFirstPagePromotionGoodsList } from '@/hooks/query/usePromotion';
 import Link from 'next/link';
 import React from 'react';
 
-const EventItemTotalSection = () => {
+interface EventItemTotalSectionProps {
+  category: Convenience;
+}
+
+const mappingSegments: Record<PromotionGoodsCategory, Convenience> = {
+  ALL: 'ALL',
+  CU: 'CU',
+  GS25: 'GS25',
+  SEVEN11: '7Eleven',
+  EMART24: 'Emart24',
+} as const;
+
+const EventItemTotalSection = ({ category }: EventItemTotalSectionProps) => {
+  const { data } = useGetFirstPagePromotionGoodsList({
+    type: EventMapping[category],
+  });
   return (
     <div className="px-[20px] pb-[75px] pt-[34.5px]">
       <div className="flex items-center justify-between pb-[39.5px]">
@@ -15,18 +34,19 @@ const EventItemTotalSection = () => {
         </Link>
       </div>
       <div className="flex flex-wrap items-start justify-start gap-x-[18px] gap-y-[50px]">
-        {/* {Array.from({ length: 8 }).map((_, i) => (
+        {data.data.map((promotion) => (
           <EventItemCard
-            key={i}
+            key={promotion.goodsNo}
             eventItem={{
-              eventType: 'ONE_PLUS_ONE',
-              imageUrl: pyeonImage,
-              price: 20000,
-              title: 'asdfasdf',
-              convenience: '7Eleven',
+              eventType: promotion.promotionType,
+              imageUrl: promotion.goodsImageUrl,
+              price: promotion.goodsPrice,
+              title: promotion.goodsName,
+              goodsNo: promotion.goodsNo,
+              convenience: mappingSegments[promotion.storeName],
             }}
           />
-        ))} */}
+        ))}
       </div>
     </div>
   );

--- a/apps/web/src/app/event/[category]/detail/[id]/page.tsx
+++ b/apps/web/src/app/event/[category]/detail/[id]/page.tsx
@@ -1,10 +1,12 @@
+'use client';
 import { Convenience } from '@/app/type';
+import ApiErrorBoundary from '@/components/ApiErrorBoundary';
+import LoadingIndicator from '@/components/LoadingIndicator';
 import TopButton from '@/components/TopButton';
+import { useQueryErrorResetBoundary } from '@tanstack/react-query';
 import React, { Suspense } from 'react';
 import EventItemDetailSection from './components/EventItemDetailSection';
 import EventItemTotalSection from './components/EventItemTotalSection';
-import LoadingIndicator from '@/components/LoadingIndicator';
-import ApiErrorBoundary from '@/components/ApiErrorBoundary';
 
 interface EventItemDetailPageProps {
   params: { category: Convenience; id: string };
@@ -13,16 +15,19 @@ interface EventItemDetailPageProps {
 const EventItemDetailPage = ({
   params: { category, id },
 }: EventItemDetailPageProps) => {
+  const { reset } = useQueryErrorResetBoundary();
   return (
     <div>
-      <div className="border-b border-[#D7D7D7] bg-white">
+      <ApiErrorBoundary onReset={reset}>
         <Suspense fallback={<LoadingIndicator />}>
-          <EventItemDetailSection goodsNo={Number(id)} />
+          <div className="border-b border-[#D7D7D7] bg-white">
+            <EventItemDetailSection goodsNo={Number(id)} />
+          </div>
+          <div className="mt-[15px] bg-white">
+            <EventItemTotalSection category={category} />
+          </div>
         </Suspense>
-      </div>
-      <div className="mt-[15px] bg-white">
-        <EventItemTotalSection />
-      </div>
+      </ApiErrorBoundary>
       <div className="fixed bottom-7 right-6 z-50 ml-auto mr-auto">
         <TopButton />
       </div>

--- a/apps/web/src/app/event/[category]/detail/[id]/page.tsx
+++ b/apps/web/src/app/event/[category]/detail/[id]/page.tsx
@@ -1,19 +1,10 @@
 import { Convenience } from '@/app/type';
-import BasicLayout from '@/components/BasicLayout';
-import HomeIconButton from '@/components/HomeIconButton';
-import SearchIconButton from '@/components/SearchIconButton';
-import TabCategory from '@/components/TabCategory';
 import TopButton from '@/components/TopButton';
-import { CONVENIENCE } from '@/constants/conveniences';
-import React from 'react';
+import React, { Suspense } from 'react';
 import EventItemDetailSection from './components/EventItemDetailSection';
 import EventItemTotalSection from './components/EventItemTotalSection';
-
-const categoryInfoList = CONVENIENCE.map((convenience) => ({
-  category: convenience,
-  label: convenience,
-  href: `/event/${convenience}`,
-}));
+import LoadingIndicator from '@/components/LoadingIndicator';
+import ApiErrorBoundary from '@/components/ApiErrorBoundary';
 
 interface EventItemDetailPageProps {
   params: { category: Convenience; id: string };
@@ -25,7 +16,9 @@ const EventItemDetailPage = ({
   return (
     <div>
       <div className="border-b border-[#D7D7D7] bg-white">
-        <EventItemDetailSection />
+        <Suspense fallback={<LoadingIndicator />}>
+          <EventItemDetailSection goodsNo={Number(id)} />
+        </Suspense>
       </div>
       <div className="mt-[15px] bg-white">
         <EventItemTotalSection />

--- a/apps/web/src/components/ApiErrorBoundary.tsx
+++ b/apps/web/src/components/ApiErrorBoundary.tsx
@@ -39,6 +39,7 @@ class ApiErrorBoundary extends React.Component<ApiErrorBoundaryProps, State> {
         error: apiError,
       };
     }
+
     return {
       shouldHandleError: true,
       shouldRethrow: false,

--- a/apps/web/src/hooks/query/usePromotion.ts
+++ b/apps/web/src/hooks/query/usePromotion.ts
@@ -2,6 +2,7 @@ import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import {
   type PromotionGoodsParams,
   getPromotionGoodsList,
+  getPromotionGoods,
 } from '@/apis/promotion';
 
 export const promotionQueryKey = {
@@ -12,6 +13,15 @@ export const promotionQueryKey = {
   details: () => [...promotionQueryKey.all, 'detail'] as const,
   detail: (goodsNo: number) =>
     [...promotionQueryKey.details(), goodsNo] as const,
+};
+
+export const useGetPromotionGoods = (goodsNo: number) => {
+  return useQuery({
+    queryKey: promotionQueryKey.detail(goodsNo),
+    queryFn: () => getPromotionGoods(goodsNo),
+    suspense: true,
+    useErrorBoundary: true,
+  });
 };
 
 export const useGetPromotionGoodsList = ({

--- a/apps/web/src/hooks/query/useRecommendation.ts
+++ b/apps/web/src/hooks/query/useRecommendation.ts
@@ -1,4 +1,5 @@
 import {
+  getRecommendationBanners,
   getRecommendationContents,
   getRecommendationList,
 } from '@/apis/recommendation';
@@ -20,6 +21,8 @@ const queryKeyRecommendationDetail = (id: number) => [
   'contents',
   id,
 ];
+const queryKeyBannerRecommendationList = () =>
+  [...queryKeyRecommendtaion, 'list', 'banner'] as const;
 
 export const useGetRecommendationList = (params: RecommendationListParams) => {
   const queryParams = {
@@ -35,17 +38,11 @@ export const useGetRecommendationList = (params: RecommendationListParams) => {
   });
 };
 
-export const useGetRecommendationContents = (id: number) => {
+export const useGetRecommendationContents = () => {
   return useQuery({
-    queryKey: queryKeyRecommendationDetail(id),
-    queryFn: () => getRecommendationContents(id),
+    queryKey: queryKeyBannerRecommendationList(),
+    queryFn: () => getRecommendationBanners(),
+    suspense: true,
     useErrorBoundary: true,
-    select(data) {
-      return {
-        ...data,
-        recommendStartDate: data.recommendStartDate.replaceAll('-', '.'),
-        recommendEndDate: data.recommendEndDate.replaceAll('-', '.'),
-      };
-    },
   });
 };

--- a/apps/web/src/hooks/query/useRecommendation.ts
+++ b/apps/web/src/hooks/query/useRecommendation.ts
@@ -38,7 +38,22 @@ export const useGetRecommendationList = (params: RecommendationListParams) => {
   });
 };
 
-export const useGetRecommendationContents = () => {
+export const useGetRecommendationContents = (id: number) => {
+  return useQuery({
+    queryKey: queryKeyRecommendationDetail(id),
+    queryFn: () => getRecommendationContents(id),
+    useErrorBoundary: true,
+    select(data) {
+      return {
+        ...data,
+        recommendStartDate: data.recommendStartDate.replaceAll('-', '.'),
+        recommendEndDate: data.recommendEndDate.replaceAll('-', '.'),
+      };
+    },
+  });
+};
+
+export const useGetRecommendationBanners = () => {
   return useQuery({
     queryKey: queryKeyBannerRecommendationList(),
     queryFn: () => getRecommendationBanners(),


### PR DESCRIPTION
## 한 줄 요약
- 행사상품 디테일 페이지 api 연동

## 자세한 내용
- 추천 배너 조회를 위해`useGetRecommendationBanners` 추가
- 행사상품 디테일 조회를 위해 `useGetPromotionGoods` 추가
- `LoadingIndicator` 적용
