### PR TITLE
feat(web): 이벤트 리스트 페이지 빈 상품 ui

### DIFF
--- a/apps/web/src/app/event/[category]/components/EventItems.tsx
+++ b/apps/web/src/app/event/[category]/components/EventItems.tsx
@@ -25,6 +25,7 @@ const EventItems = ({ category, eventType }: EventItemsProps) => {
     type: EventMapping[category],
     promotionType: eventType,
   });
+
   const { ref, inView } = useInView();
 
   useEffect(() => {
@@ -36,20 +37,24 @@ const EventItems = ({ category, eventType }: EventItemsProps) => {
   return (
     <>
       <div className="flex flex-wrap items-start justify-start gap-x-[18px] gap-y-[50px]">
-        {data?.pages.map((page) =>
-          page.data.map((promotion, idx) => (
-            <EventItemCard
-              key={`${idx}-${promotion.goodsNo}`}
-              eventItem={{
-                eventType: promotion.promotionType,
-                imageUrl: promotion.goodsImageUrl,
-                price: promotion.goodsPrice,
-                title: promotion.goodsName,
-                goodsNo: promotion.goodsNo,
-                convenience: mappingSegments[promotion.storeName],
-              }}
-            />
-          )),
+        {data?.pages[0].data.length ? (
+          data.pages.map((page) =>
+            page.data.map((promotion, idx) => (
+              <EventItemCard
+                key={`${idx}-${promotion.goodsNo}`}
+                eventItem={{
+                  eventType: promotion.promotionType,
+                  imageUrl: promotion.goodsImageUrl,
+                  price: promotion.goodsPrice,
+                  title: promotion.goodsName,
+                  goodsNo: promotion.goodsNo,
+                  convenience: mappingSegments[promotion.storeName],
+                }}
+              />
+            )),
+          )
+        ) : (
+          <div> 상품이 없습니다. </div>
         )}
       </div>
       {isFetchingNextPage ? <div>Loading...</div> : <div ref={ref} />}

--- a/apps/web/src/hooks/query/usePromotion.ts
+++ b/apps/web/src/hooks/query/usePromotion.ts
@@ -40,7 +40,8 @@ export const useGetPromotionGoodsList = ({
         cursor: pageParam,
       }),
     getNextPageParam: (lastPage) =>
-      lastPage.pageInfo.totalPages !== lastPage.nextCursor
+      lastPage.pageInfo.totalPages !== lastPage.nextCursor &&
+      lastPage.data.length
         ? lastPage.nextCursor
         : undefined,
     suspense: true,


### PR DESCRIPTION
## 한 줄 요약
- 이벤트 리스트 페이지에서 행사 타입 조회시 행사 상품이 없을 경우에 대한 ui 작업

## 자세한 내용
- `getNextPageParam` 쪽 조건을 잘못 작성해서 첫 페이지 호출시 `totalPages`가 `0`이라면 `nextCursor`는 `1`이므로 다음 페이지 호출이 또 일어났다. 이를 막기 위해 list의 length 도 같이 조건에 추가
- 첫 페이지의 데이터 길이가 0일 경우 `상품이 없습니다.` 문구 추가.
