### PR TITLE
feat(web): 검색 결과 페이지 api 작업

### DIFF
--- a/apps/web/src/apis/promotion.ts
+++ b/apps/web/src/apis/promotion.ts
@@ -8,6 +8,7 @@ import type {
 
 export interface PromotionGoodsParams {
   type: PromotionGoodsCategory;
+  size?: number;
   promotionType?: PromotionType;
   keyword?: string;
   cursor?: number;

--- a/apps/web/src/app/search/components/SearchResultList.tsx
+++ b/apps/web/src/app/search/components/SearchResultList.tsx
@@ -1,0 +1,69 @@
+import { PromotionGoodsCategory } from '@/apis/type';
+import { Convenience } from '@/app/type';
+import EventItemCard from '@/components/EventItemCard';
+import { EventMapping } from '@/constants/conveniences';
+import {
+  useGetFirstPagePromotionGoodsList,
+  useGetPromotionGoodsList,
+} from '@/hooks/query/usePromotion';
+import React, { useEffect } from 'react';
+import { useInView } from 'react-intersection-observer';
+
+interface SearchResultListProps {
+  category: Convenience;
+  word: string;
+}
+
+const mappingSegments: Record<PromotionGoodsCategory, Convenience> = {
+  ALL: 'ALL',
+  CU: 'CU',
+  GS25: 'GS25',
+  SEVEN11: '7Eleven',
+  EMART24: 'Emart24',
+} as const;
+
+const SearchResultList = ({ category, word }: SearchResultListProps) => {
+  const { data, fetchNextPage, isFetchingNextPage } = useGetPromotionGoodsList({
+    type: EventMapping[category],
+    keyword: word,
+  });
+  const { ref, inView } = useInView();
+
+  useEffect(() => {
+    if (inView && data?.pages) {
+      fetchNextPage();
+    }
+  }, [inView]);
+
+  return (
+    <>
+      <div className="pb-[25px] pt-[40px] text-xl font-bold">
+        <span>{`${data?.pages[0].pageInfo.totalElements}개의 검색결과`}</span>
+      </div>
+      <div className="flex flex-wrap items-start justify-start gap-x-[18px] gap-y-[50px]">
+        {data?.pages[0].data.length ? (
+          data.pages.map((page) =>
+            page.data.map((promotion, idx) => (
+              <EventItemCard
+                key={`${idx}-${promotion.goodsNo}`}
+                eventItem={{
+                  eventType: promotion.promotionType,
+                  imageUrl: promotion.goodsImageUrl,
+                  price: promotion.goodsPrice,
+                  title: promotion.goodsName,
+                  goodsNo: promotion.goodsNo,
+                  convenience: mappingSegments[promotion.storeName],
+                }}
+              />
+            )),
+          )
+        ) : (
+          <div> 상품이 없습니다. </div>
+        )}
+      </div>
+      {isFetchingNextPage ? <div>Loading...</div> : <div ref={ref} />}
+    </>
+  );
+};
+
+export default SearchResultList;

--- a/apps/web/src/app/search/view/SearchResultView.tsx
+++ b/apps/web/src/app/search/view/SearchResultView.tsx
@@ -9,7 +9,6 @@ import SearchResultList from '../components/SearchResultList';
 const SearchResultView = () => {
   const searchParams = useSearchParams();
   const word = searchParams.get('word');
-  console.log('word', word);
   const category = searchParams.get('category') as Convenience;
   const categoryInfoList = CONVENIENCE.map((convenience) => ({
     category: convenience,

--- a/apps/web/src/app/search/view/SearchResultView.tsx
+++ b/apps/web/src/app/search/view/SearchResultView.tsx
@@ -1,14 +1,15 @@
 'use client';
 import { Convenience } from '@/app/type';
-import EventItemCard from '@/components/EventItemCard';
 import TabCategory from '@/components/TabCategory';
 import { CONVENIENCE } from '@/constants/conveniences';
-import { pyeonImage } from '@/dummy/image';
 import { useSearchParams } from 'next/navigation';
+import { Suspense } from 'react';
+import SearchResultList from '../components/SearchResultList';
 
 const SearchResultView = () => {
   const searchParams = useSearchParams();
   const word = searchParams.get('word');
+  console.log('word', word);
   const category = searchParams.get('category') as Convenience;
   const categoryInfoList = CONVENIENCE.map((convenience) => ({
     category: convenience,
@@ -25,23 +26,9 @@ const SearchResultView = () => {
         />
       </div>
       <div className="px-[20px]">
-        <div className="pb-[25px] pt-[40px] text-xl font-bold">
-          <span>292개의 검색결과</span>
-        </div>
-        <div className="flex flex-wrap items-start justify-start gap-x-[18px] gap-y-[50px]">
-          {/* {Array.from({ length: 8 }).map((_, i) => (
-            <EventItemCard
-              key={i}
-              eventItem={{
-                eventType: 'ONE_PLUS_ONE',
-                imageUrl: pyeonImage,
-                price: 20000,
-                title: 'asdfasdf',
-                convenience: '7Eleven',
-              }}
-            />
-          ))} */}
-        </div>
+        <Suspense>
+          <SearchResultList category={category} word={word} />
+        </Suspense>
       </div>
     </div>
   );

--- a/apps/web/src/hooks/query/usePromotion.ts
+++ b/apps/web/src/hooks/query/usePromotion.ts
@@ -28,6 +28,7 @@ export const useGetPromotionGoodsList = ({
   type,
   promotionType,
   keyword,
+  size,
   cursor,
 }: PromotionGoodsParams) => {
   return useInfiniteQuery({
@@ -37,11 +38,11 @@ export const useGetPromotionGoodsList = ({
         type,
         promotionType,
         keyword,
+        size,
         cursor: pageParam,
       }),
     getNextPageParam: (lastPage) =>
-      lastPage.pageInfo.totalPages !== lastPage.nextCursor &&
-      lastPage.data.length
+      lastPage.pageInfo.totalPages !== lastPage.nextCursor
         ? lastPage.nextCursor
         : undefined,
     suspense: true,


### PR DESCRIPTION
## 한 줄 요약
- 검색 결과 페이지 api 연동 작업

## 자세한 내용
- 기존의 `SearchResultView` 에 있던 `EventItemCard`를 `SearchResultList` 컴포넌트 안에 작성해서 api 호출부와 ui로직을 나눔
- `PromotionGoodsParams`에 size 타입 추가